### PR TITLE
Generate stations_mini.csv with suggestable stations only

### DIFF
--- a/build_station_index.py
+++ b/build_station_index.py
@@ -14,6 +14,6 @@ trainline-eu/stations/master/stations.csv"
 csv_content = requests.get(_STATIONS_CSV_FILE).content
 df = pd.read_csv(io.StringIO(csv_content.decode('utf-8')),
                  sep=';', index_col=0, low_memory=False)
-
+df = df[df.is_suggestable == 't']
 df_mini = df.name.str.lower()
-df_mini.to_csv("stations_mini.csv", sep=';', encoding='utf-8')
+df_mini.to_csv("stations_mini.csv", sep=';', encoding='utf-8', header=False)

--- a/trainline/stations_mini.csv
+++ b/trainline/stations_mini.csv
@@ -1,46 +1,33 @@
-1;château-arnoux—st-auban
 2;château-arnoux—st-auban
 3;château-arnoux mairie
-4;digne-les-bains
 6;digne-les-bains
 7;la crau
 8;aire-sur-l’adour
 9;cagnes-sur-mer
-10;menton
 11;menton
 12;menton—garavan
-16;vievola
-17;vievola
 18;vievola
 19;mandelieu-la-napoule
-23;decazeville
 24;decazeville centre
 25;viviez—decazeville
 26;decazeville fontvergne
-27;st-sever calvados
 28;st-sever centre
 29;st-sever calvados
 30;vire
-31;vire centre
-32;vire
-33;marans
 34;marans centre
 35;marans
 36;uzerche
 38;dijon ville
-40;pontrieux
 41;pontrieux halte
 42;pontrieux
 43;auboué
 44;périgueux
 45;besançon viotte
 47;douarnenez office de tourisme
-50;concarneau
 51;concarneau port
 52;concarneau
 55;aboncourt
 56;aiton—bourgneuf
-57;colomiers
 58;colomiers
 59;colomiers lycée international
 60;labège
@@ -49,7 +36,6 @@
 63;azay-le-rideau mairie
 64;albas
 65;abancourt
-66;lunel
 67;lunel-viel
 68;lunel
 72;moirans
@@ -57,7 +43,6 @@
 74;accolay
 76;dole ville
 77;dax
-80;rezé
 82;rezé—pont-rousseau
 83;cherbourg
 84;angers st-laud
@@ -70,42 +55,30 @@
 93;laval
 94;accous
 95;achiet
-96;louverné
 97;louverné
 98;louverné centre
-99;mayenne
 100;mayenne
 101;mayenne centre
-104;arnage
 105;arnage
 106;arnage centre
-107;carnac
 108;plouharnel—carnac
 109;les sables-blancs
 110;carnac
-111;st-pierre-quiberon
 112;l’isthme
 113;st-pierre-quiberon
 114;metz
-115;forbach
 117;forbach
-118;sarreguemines
 119;sarreguemines poste
 121;sarreguemines
 122;dunkerque
 123;lille-flandres
 124;haubourdin
 125;tourcoing
-126;nomain
-127;nomain-ouvignies
 128;nomain
-129;croix
 130;croix—wasquehal
 131;croix-l’allumette
 132;roubaix
-136;jeumont
 137;jeumont
-139;bellegarde-sur-valserine
 140;bellegarde-sur-valserine
 141;bellegarde-sur-valserine lycée musinens
 143;briouze
@@ -115,36 +88,27 @@
 151;pau
 152;hendaye
 153;strasbourg
-154;mertzwiller
 155;mertzwiller
 157;colmar
 158;mulhouse
-159;st-louis (haut rhin)
 160;st-louis la-chaussée
 161;st-louis
-162;thann
 163;thann
 164;thann—st-jacques
 165;givors canal
-166;aspach-le-haut
 167;aspach-le-haut
 168;aspach-le-bas
 171;avignon centre
 172;le mans
 173;joué-lès-tours berthelot
-174;eu
-175;eu-la-mouillette
 176;eu
 177;alleyras
 178;le havre
-179;harfleur
 180;harfleur-halte
 181;harfleur
-182;montivilliers
 184;montivilliers
 186;dieppe
 187;fontainebleau—avon
-188;péronne
 189;péronne centre
 190;péronne la chapelette
 191;albi ville
@@ -153,7 +117,6 @@
 195;fréjus
 196;fontenay-le-comte
 197;acheux-franleu
-198;st-hilaire-de-riez
 199;st-hilaire-de-riez
 200;st-hilaire-de-riez centre
 201;la clayette—baudemont
@@ -167,9 +130,7 @@
 211;limoges bénédictins
 212;modane
 213;agos
-214;argenton-sur-creuse
 215;argenton-sur-creuse
-216;argenton-sur-creuse gare routière
 217;roye
 218;agay
 220;versailles
@@ -182,19 +143,15 @@
 239;aillevillers
 241;ailly-sur-noye
 246;ailly-sur-somme
-249;aigues-vives (gard)
 252;aiserey
 264;vicq-sur-breuilh
 265;st-hilaire-bonneval
-266;boisseuil
 267;azay-sur-indre
-286;mouroux
 292;alet-les-bains
 293;allassac
 295;albens
 302;pierre-buffière ville
 303;aix la marsalouse
-304;la ferté-sous-jouarre
 311;merten
 313;la ferté-milon
 314;neuilly-st-front
@@ -242,9 +199,7 @@
 367;ingolsheim
 372;hertzing
 373;bébing
-376;drouilly
 377;aiguillon
-378;st-martin-aux-champs
 379;bouilly
 380;chamoy
 381;jeugny
@@ -253,8 +208,6 @@
 384;st-jean-de-bonneval
 385;st-phal monument aux morts
 386;villery
-387;neuvy-sautour rn
-388;brienon mairie
 389;st-lyé
 390;payns
 391;savières
@@ -268,8 +221,6 @@
 401;aigueperse
 402;vendeuvre
 403;bar-sur-aube
-404;st-florentin hôtel de ville
-405;laroche-migennes hôtel terminus
 406;foug
 407;fontenoy-sur-moselle
 408;liverdun
@@ -428,13 +379,11 @@
 584;ste-marguerite—remomeix
 585;blanchifontaine
 586;frémifontaine
-587;la bresse
 588;laneuveville-aux-bois
 589;vallois
 591;greux
 592;goussaincourt
 593;burey-la-côte
-595;taillancourt
 598;montbré
 599;trois-puits
 600;muizon
@@ -453,7 +402,6 @@
 613;prunay
 614;sillery
 615;sept-saulx
-616;mairy-sur-marne
 617;courcy-brimont
 618;loivre
 619;guignicourt
@@ -491,15 +439,11 @@
 651;beauchastel
 652;remilly-aillicourt
 653;bénestroff
-654;bagnoles-de-l’orne
 656;anchamps
 657;fépin
 659;brest
 660;wadelincourt
 661;la ferté-sur-chiers
-664;songy
-665;loisy-sur-marne
-666;pringy (marne)
 667;vitry-le-françois
 668;mourmelon-le-petit
 669;uxegney
@@ -509,7 +453,6 @@
 673;st-âme
 674;st-âme—le syndicat
 677;suippes
-678;ste-ménéhould
 679;st-dizier
 680;revigny
 681;nançois-tronville
@@ -527,20 +470,16 @@
 695;les islettes
 696;clermont-en-argonne
 697;étain
-701;vaucouleurs
 702;neuville-les-vaucouleurs
 703;burey-en-vaux
 704;maxey-sur-vaise
 705;hasenrain
-706;brunstatt
 707;flaxlanden
 708;beillant
 709;blesme-haussignemont
 710;tagolsheim
 711;walheim
-712;ballersdorf
 713;biarritz
-714;valdieu
 715;graffenwald
 716;st-andré (haut rhin)
 717;colmar mésanges
@@ -586,8 +525,6 @@
 762;oderen
 763;kruth
 764;breitenbach
-765;richwiller
-766;wittelsheim
 767;staffelfelden
 768;bollwiller
 769;raedersheim
@@ -595,7 +532,6 @@
 771;muhlbach-sur-munster
 772;malmerspach
 773;metzéral
-774;sundhoffen
 775;bas-evette
 778;bort-les-orgues
 779;trois-chênes
@@ -621,14 +557,12 @@
 807;béning
 809;mont-le-vernois
 810;luxeuil-les-bains
-811;basel sbb
 812;loupershouse
 813;walygator parc
 814;maizières-lès-metz
 815;uckange
 816;knutange—nilvange
 817;hayange
-818;aubusson gare routière
 819;metzeresche
 820;yutz
 821;kuntzig
@@ -639,7 +573,6 @@
 827;bordeaux
 828;bordeaux st-jean
 829;boé
-830;ébersviller
 831;anzeling
 832;freistroff
 833;remelfang
@@ -679,7 +612,6 @@
 870;baroncourt
 871;hatrize
 872;valleroy—moineville
-873;bourges gare routière
 874;baronville
 875;vahl-les-bénestroff
 876;hargarten—falck
@@ -706,7 +638,6 @@
 901;zetting
 902;wittring
 903;herbitzheim
-904;ravezies
 905;boussens
 906;woelfling-lès-sarreguemines
 907;rohrbach-lès-bitche
@@ -738,7 +669,6 @@
 936;wilwisheim
 937;dettwiller
 938;strasbourg roethig
-939;zornhoff—monswiller
 940;graffenstaden
 941;geispolsheim
 942;fegersheim—lipsheim
@@ -765,10 +695,7 @@
 964;hattmatt
 965;dossenheim-sur-zinsel
 966;neuwiller-les-saverne
-967;uberach
 970;kaltenhouse
-971;volgelsheim
-972;kehl grenze
 973;neubourg
 974;pfaffenhoffen
 975;bouxwiller
@@ -798,7 +725,7 @@
 1001;ettendorf
 1002;alteckendorf
 1003;tauxigny
-1004;griesbach
+1004;griesbach le bastberg
 1005;niedermodern
 1006;ebersheim
 1007;kogenheim
@@ -864,7 +791,6 @@
 1080;loudrefing
 1081;mittersheim
 1083;oberstinzel
-1085;sarraltroff
 1086;bettborn
 1088;fénétrange
 1089;niederstinzel
@@ -875,7 +801,6 @@
 1094;schopperten
 1095;keskastel
 1096;oermingen
-1097;voellerdingen
 1099;diemeringen
 1100;tieffenbach—struth
 1101;frohmuhl
@@ -890,14 +815,7 @@
 1116;sorèze
 1119;carcassonne
 1120;balsièges
-1121;tournai frontière
-1122;froyennes
-1123;châlons-en-champagne
-1124;châlons-en-champagne tissier
 1125;châlons-en-champagne
-1126;châlons-en-champagne bagatelle
-1128;paris gare du nord
-1129;paris gare du nord
 1137;culmont-chalindrey
 1139;capdenac
 1143;aéroport paris roissy charles de gaulle cdg
@@ -914,19 +832,16 @@
 1166;crouy
 1167;margival
 1168;jaux
-1173;choisy-au-bac
 1175;esches
 1176;vineuil-st-firmin
 1177;courteuil
 1178;st-nicolas-aumont
-1179;cannes
 1180;cannes
 1181;cannes—la bocca
 1182;st-jean-le-centenier
 1183;cholet
 1185;longueil-annel
 1187;corcy
-1188;paris gare du nord 2
 1193;clermont-ferrand
 1198;conflans—jarny
 1205;laigneville
@@ -991,10 +906,8 @@
 1307;lesquin
 1308;annappes
 1309;baisieux
-1313;mouscron
 1314;lezennes
 1315;mont-de-terre
-1316;chambourg
 1317;chambourg
 1318;nieppe
 1319;marquette
@@ -1023,11 +936,9 @@
 1346;avesnes
 1347;dompierre (hauts-de-france)
 1348;velle-le-châtel
-1349;colmar
 1350;leval
 1351;berlaimont
 1352;le quesnoy
-1354;quevy frontière
 1355;marle-sur-serre
 1356;vervins
 1357;origny-en-thiérache
@@ -1062,7 +973,6 @@
 1394;chaourse
 1395;magny
 1396;chéry-les-rozoy place de l’église
-1397;rouvroy—résigny—grandrieux
 1398;le fréty st-gorgon
 1399;la ferée
 1400;mainbressy
@@ -1075,8 +985,6 @@
 1410;miannay
 1412;brunvillers-la-motte
 1413;crèvecœur-le-petit
-1414;goyencourt
-1415;royaucourt
 1416;ste-geneviève
 1417;calais
 1419;calais fréthun
@@ -1141,13 +1049,11 @@
 1479;maignelay centre
 1480;dompierre monument aux morts (hauts-de-france)
 1481;marchelepot
-1482;pont-les-brie
 1483;cartigny
 1484;châteaubriant
 1485;hattencourt
 1486;laboissière-fescamps
 1487;le château-d’oléron
-1489;chartres gare routière
 1491;lamotte-brebières
 1492;heilly
 1493;buire-sur-l’ancre
@@ -1155,12 +1061,9 @@
 1497;dommartin-remiencourt
 1498;thézy-glimont
 1499;le castelet
-1503;châteauroux
-1504;châteauroux gare routière
 1505;castelnaudary
 1506;famechon
 1507;wacquemoulin
-1508;hyencourt-le-grand
 1509;eterpigny
 1510;doingt
 1511;tincourt-boucly
@@ -1171,7 +1074,6 @@
 1518;laucourt
 1519;dancourt
 1520;châteaudun
-1521;grivillers
 1522;faverolles
 1523;heilles-mouchy
 1524;montreuil-sur-thérain
@@ -1190,7 +1092,6 @@
 1541;neufchâtel-hardelot
 1542;pont-de-briques
 1543;wimille—wimereux
-1544;irún
 1545;montreuil-sur-mer
 1546;brimeux
 1547;beaurainville
@@ -1202,7 +1103,6 @@
 1553;caffiers
 1554;marquise-rinxent
 1555;noyelles-sur-mer
-1557;clermont-ferrand
 1558;clermont-ferrand la pardieu
 1559;clermont-ferrand la rotonde
 1560;quesnoy-le-montant
@@ -1277,13 +1177,11 @@
 1634;arleux
 1635;brunémont
 1636;aubigny-au-bac
-1638;fressies
 1639;darsac
 1641;escaudœuvres
 1642;maurois
 1643;bertry
 1644;caudry
-1645;montauban-de-bretagne
 1647;cattenières
 1648;wambaix
 1649;cerans-foulletourte
@@ -1303,7 +1201,6 @@
 1683;amécourt-talmontier
 1684;neuf-marché
 1685;gournay—ferrières
-1691;conflans-fin-d’oise
 1701;bréval
 1702;dourdan
 1754;la bonneville-sur-iton
@@ -1316,7 +1213,6 @@
 1763;marcilly-sur-tille
 1764;raze
 1765;mauléon brossardière
-1767;paris montparnasse 2 pasteur
 1778;die
 1782;dijon
 1783;dijon porte neuve
@@ -1413,14 +1309,12 @@
 1915;foucart—alvimare
 1916;dol-de-bretagne
 1917;don-sainghin
-1918;dommerville
 1920;fécamp
 1921;dourges
 1922;épouville
 1923;rolleville
 1924;agen dot
 1925;agen cimetière
-1926;dieppe
 1928;agen magnolias
 1929;arques-la-bataille
 1930;st-vaast-d’équiqueville
@@ -1438,7 +1332,6 @@
 1944;gaillon—aubevoye
 1945;st-pierre-du-vauvray
 1946;pont-de-l’arche
-1948;louviers
 1949;rosny-sur-seine
 1950;bonnières
 1951;bures-en-bray carrefour
@@ -1446,11 +1339,9 @@
 1953;eragny—bazincourt
 1954;mesnières-en-bray centre
 1959;dracy-st-loup
-1961;dreux gare routière
 1962;bretteville—norrey
 1963;audrieu
 1964;le molay-littry
-1965;dourdan
 1967;frénouville—cagny
 1968;moult—argences
 1969;st-pierre-sur-dives
@@ -1485,7 +1376,6 @@
 2002;massy—palaiseau
 2004;la ferté-macé
 2006;avranches
-2008;la ferté-macé
 2009;la ferté-macé place neustadt
 2010;incarville
 2011;lonlay-le-tesson
@@ -1536,9 +1426,7 @@
 2062;plaintel
 2063;quintin
 2064;dyo
-2065;le pas
 2066;plœuc—l’hermitage
-2067;uzel
 2068;la motte
 2069;loudéac centre
 2070;gourin
@@ -1589,7 +1477,6 @@
 2122;st-étienne châteaucreux
 2123;st-étienne carnot
 2125;guiscriff
-2126;roscoff
 2127;argol
 2128;telgruc
 2129;tal-ar-groas
@@ -1652,7 +1539,6 @@
 2188;port-st-père st-mars
 2189;bourgneuf-en-retz
 2192;pornic
-2193;bourgneuf-en-retz
 2194;machecoul
 2195;vertou
 2196;la haie-fouassière
@@ -1682,7 +1568,6 @@
 2224;champtoce-sur-loire
 2225;ingrandes-sur-loire
 2227;varades—st-florent-le-vieil
-2228;château-gontier
 2229;segré
 2231;l’île-d’elle
 2232;châtelaillon
@@ -1690,9 +1575,8 @@
 2234;surgères
 2235;mauzé
 2236;prin-deyrançon
-2237;épannes
 2238;fors
-2239;marigny
+2239;marigny (deux-sèvres)
 2240;beauvoir-sur-niort
 2241;prissé-la-charrière
 2242;la crèche
@@ -1715,11 +1599,9 @@
 2264;les clouzeaux
 2265;la mothe-achard
 2266;olonne-sur-mer
-2267;soullans centre
 2268;torfou
 2270;noirterre
 2271;cerizay
-2272;st-mesmin-le-vieux
 2273;pouzauges
 2275;chavagnes-les-redoux
 2278;brion-près-thouet
@@ -1769,7 +1651,6 @@
 2330;baladou
 2331;somport
 2334;ayron
-2335;angerville
 2339;cercottes
 2340;chevilly
 2341;artenay
@@ -1783,11 +1664,8 @@
 2349;nouan-le-fuzelier
 2351;theillay
 2354;epuisay
-2355;monnerville
-2358;guillerval
 2362;monnerville
 2363;guillerval
-2369;brétigny
 2388;auneau
 2390;voves
 2391;bonneval
@@ -2013,7 +1891,6 @@
 2668;astaffort
 2669;fleurance vignette
 2670;montestruc-sur-gers
-2671;ste-christie carrefour
 2672;rambert—preignan
 2673;pont-du-casse
 2674;laroque
@@ -2057,10 +1934,8 @@
 2712;st-sébastien
 2713;la coquille
 2714;le dorat
-2715;assier
 2716;assier
 2717;l’aiguille
-2718;figeac
 2719;figeac
 2720;verneuil-sur-vienne
 2721;st-victurnien
@@ -2116,7 +1991,6 @@
 2773;négrondes
 2774;château-l’évêque
 2775;marsac (dordogne)
-2776;fontenay-le-comte
 2777;la cave
 2778;razac
 2779;st-astier
@@ -2155,14 +2029,9 @@
 2815;chabenet
 2816;arc-les-gray
 2817;éguzon
-2818;issoudun
-2819;montierchaume
 2820;villedieu-sur-indre
 2822;buzançais
 2823;clion-sur-indre
-2824;châtillon-sur-indre
-2825;nîmes gare
-2827;verneuil—st-germain
 2830;marsac (creuse)
 2831;vieilleville
 2832;bourganeuf
@@ -2180,7 +2049,6 @@
 2844;franois
 2845;clairavaux
 2847;folligny
-2848;le locle col des roches
 2850;fougères
 2851;limoux flassian
 2852;st-palais
@@ -2255,10 +2123,8 @@
 2923;floirac
 2924;rocamadour—padirac
 2925;gramat
-2927;soulac-sur-mer église
 2930;gourdon
 2932;dégagnac
-2935;soulac-sur-mer
 2936;espère—caillac
 2937;aubin
 2938;cransac
@@ -2345,7 +2211,6 @@
 3035;izaux
 3036;labastide
 3039;fréchet-aure
-3040;galiax
 3041;galié
 3042;saléchan—siradan
 3045;mazères-sur-salat
@@ -2464,7 +2329,6 @@
 3177;maubourguet centre
 3178;caussade (hautes pyrénées)
 3179;hères
-3190;genève eaux-vives
 3192;gex centre
 3193;montaut—bétharram
 3195;coarraze—nay
@@ -2486,7 +2350,6 @@
 3232;guingamp
 3233;urdos
 3234;forges-d’abel
-3235;canfranc
 3236;boucau
 3240;saubusse-les-bains
 3241;st-geours
@@ -2504,11 +2367,8 @@
 3255;louhossoa
 3256;bidarray—pont-noblia
 3258;st-jean-pied-de-port
-3261;montierchaume bourg
-3262;cheppes-la-prairie
 3263;givors
 3264;givors ville
-3265;togny-aux-bœufs
 3266;dolleren
 3267;monswiller
 3268;wegscheid
@@ -2552,20 +2412,16 @@
 3363;vermenton
 3364;lucy-sur-cure-bessy
 3365;arcy-sur-cure
-3366;grenoble
 3367;grenoble universités gières
 3369;voutenay
 3370;sermizelles-vézelay
 3371;avallon
 3372;argent-sur-sauldre
-3373;st-genou
 3374;mailly-la-ville
 3375;montargis
 3380;souppes—château-landon
 3383;nogent-sur-vernisson
 3384;gien
-3389;paris gare de lyon a
-3390;paris gare de lyon b
 3396;pontaix
 3400;villechaud
 3402;la marche
@@ -2626,7 +2482,6 @@
 3467;villeneuve-sur-allier
 3468;bessay
 3470;varennes-sur-allier
-3472;billy—marcenat
 3473;montbeugny
 3474;thiel-sur-acolin
 3475;dompierre—sept-fons (auvergne-rhône-alpes)
@@ -2639,7 +2494,6 @@
 3482;fours
 3483;rémilly—st-honoré-les-bains
 3484;luzy
-3485;millay
 3486;corbigny
 3487;dirol
 3488;flez—cuzy—tannay
@@ -2651,7 +2505,6 @@
 3494;malbuisson
 3496;rully
 3497;paris-l’hôpital
-3498;saisy la forêt
 3499;neuilly-lès-dijon
 3500;sully le château
 3501;st-léger-du-bois—sully
@@ -2696,7 +2549,6 @@
 3547;meursault
 3548;fontaines—mercurey
 3549;nolay
-3550;épinac—les-mines
 3551;saulon
 3552;brazey-en-plaine
 3553;pagny
@@ -2709,9 +2561,7 @@
 3565;st-julien—clénay
 3566;gemeaux
 3567;is-sur-tille
-3571;champsigny
 3572;change
-3573;changey
 3575;dezize
 3578;la rivière
 3579;ste-colombe
@@ -2731,7 +2581,6 @@
 3596;morez
 3597;les hôpitaux-neufs
 3598;jougne
-3600;vallorbe frontière
 3601;besançon mouillère
 3602;montferrand—thoraise
 3603;torpes—boussières
@@ -2762,7 +2611,6 @@
 3636;hymont—mattaincourt
 3638;gilley
 3640;ambert ville
-3641;hombourg-budange
 3642;hombourg-budange la sapinière
 3645;montbarrey
 3646;salins-les-bains
@@ -2887,7 +2735,6 @@
 3783;le chambon-feugerolles
 3784;fraisse—unieux
 3785;hirson écoles
-3786;blagnac mairie
 3787;aurec
 3788;hirson
 3789;his
@@ -2899,7 +2746,6 @@
 3798;feurs
 3799;montrond-les-bains
 3800;st-fons
-3802;celles-sur-durolle
 3803;ste-pazanne rue du vigneau
 3804;néronde-sur-dore
 3805;la forie
@@ -2960,7 +2806,6 @@
 3873;vorey
 3874;chamalières-sur-loire
 3875;retournac
-3876;lagraulière
 3878;riom-es-montagnes
 3879;cerans église
 3880;massiac-blesle
@@ -3004,12 +2849,10 @@
 3926;notre-dame-de-briançon
 3927;petit-cœur—la léchère
 3928;aigueblanche
-3930;romelfing église
 3931;landry
 3932;antignac (cantal)
 3933;ambilly
 3934;st-jean-de-maurienne—arvan
-3936;romelfing route départementale
 3938;gérardmer les bas-rupts
 3939;collonges (ain)
 3940;longeray
@@ -3058,7 +2901,6 @@
 4010;châtillon-en-michaille
 4011;st-germain-de-joux
 4012;charix—lalleyriat
-4013;hirson
 4015;seyssel—corbonod
 4018;grésy-sur-aix
 4021;rumilly
@@ -3067,7 +2909,6 @@
 4025;pringy (haute savoie)
 4026;st-martin-bellevue
 4027;groisy—thorens-la-caille
-4029;chartres
 4030;chartres
 4031;st-pierre-en-faucigny
 4032;bonneville
@@ -3076,10 +2917,7 @@
 4037;magland
 4039;reignier
 4041;le trétien
-4042;les marécottes
-4043;salvan
 4044;vernayaz
-4045;martigny
 4046;chedde
 4047;servoz
 4048;viaduc-ste-marie
@@ -3113,9 +2951,6 @@
 4082;clelles—mens
 4085;lus-la-croix-haute
 4088;moirans—la-galifette
-4089;genève voyageurs
-4090;genève
-4091;lausanne
 4092;grésin
 4093;logras
 4094;sauverny
@@ -3190,10 +3025,7 @@
 4180;la brigue
 4181;tende
 4182;pins-justaret
-4183;annonay
 4184;annonay zone industrielle
-4185;limone-confine
-4186;fréjus gare autotrain
 4187;boulouris-sur-mer
 4188;le dramont
 4189;anthéor—cap-roux
@@ -3234,7 +3066,6 @@
 4340;bollène-la-croisière
 4341;le teil sablons
 4343;le teil melas
-4344;vals-les-bains—labegude
 4345;courthézon
 4346;bédarrides
 4347;sorgues—châteauneuf-du-pape
@@ -3251,15 +3082,12 @@
 4362;beauvallon
 4364;sabo
 4365;valergues—lansargues
-4366;st-brès—mudaison
 4367;baillargues
 4368;st-aunès
-4369;les mazes-le-crès
 4370;villeneuve-lès-maguelonne
 4371;vic-la-gardiole—mireval
 4372;frontignan
 4373;beaucaire
-4374;jonquières-et-st-vincent
 4375;manduel—redessan
 4376;milhaud
 4377;uchaud
@@ -3281,10 +3109,8 @@
 4395;aubiac
 4396;bessèges
 4397;robiac
-4398;gammal
 4399;molières-sur-cèze
 4400;st-ambroix
-4401;st-julien-de-cassagnas les fumades
 4402;salindres
 4403;laplume
 4404;générac
@@ -3300,7 +3126,6 @@
 4415;port-la-nouvelle
 4416;leucate—la-franqui
 4417;coursan
-4418;nissan
 4419;vias
 4420;marseillan-plage
 4421;condom
@@ -3349,7 +3174,6 @@
 4469;salses
 4470;rivesaltes
 4471;elne
-4472;port-vendres quai
 4473;lalonquette
 4474;auriac
 4475;le soler
@@ -3390,7 +3214,6 @@
 4523;st-nic—pentrez
 4526;laroche-migennes
 4528;st-florentin—vergigny
-4529;neuvy-sautour
 4532;la pouge
 4533;le verdeau
 4534;les chabannes
@@ -3409,48 +3232,36 @@
 4547;monnaie jean-baptiste moreau
 4549;cocheren village
 4550;ferney centre
-4551;le châtelard frontière
 4552;ouge
 4553;st-romain-lachalm
 4554;st-didier-en-velay
 4555;st-pal-de-mons
 4556;st-loup-sur-semouse
 4558;lyon st-exupéry tgv
-4561;noailles bourg
 4562;meymac bourg
 4564;la baule-escoublac
-4568;jussey
 4569;jussey centre
 4570;juan-les-pins
 4571;joué-lès-tours
 4572;job
 4573;josselin
 4575;juvisy
-4577;mantes-la-jolie tgv
-4578;conflans-fin-d’oise tgv
-4580;joué-lès-tours
 4582;st-julien-en-st-alban
-4583;fréjus
 4585;penhoët
 4586;kalhausen
 4587;st-jean-de-monts esplanade de la mer
 4588;st-jean-de-monts gare routière
-4589;barbâtre la fosse
 4591;beauvoir-sur-mer st-nicolas
 4593;krimmeri—meinau
 4594;les aubrais
 4595;langres
 4596;lannion
-4597;la frayère
 4598;lamballe
 4600;laqueuille
 4602;troyes lombards
-4604;albi
 4605;albi montplaisir
 4606;albi halte routière
 4607;l’arbresle
-4608;la bernerie-en-retz
-4609;le bosquet
 4610;le bois-plage-en-ré marché
 4611;la bastide—st-laurent-les-bains
 4612;le buisson
@@ -3463,23 +3274,18 @@
 4619;lacanau océan
 4620;la chapelle-st-mesmin
 4621;le châtelard
-4622;le châtelard—giétroz
 4623;le côteau
 4626;lourdes
 4628;la douzillère
 4629;lesseux—frapelle
-4630;le havre
 4631;le havre graville
 4633;l’estaque
 4636;lentilly—charpenay
-4638;la flotte port
-4640;bologne
 4641;bologne salle des fêtes
 4642;langres gendarmerie
 4643;longuyon
 4644;st-léger
 4646;st-hilaire-la-gravelle
-4647;gex
 4648;gex vertes campagnes
 4649;angoulins-sur-mer
 4650;libercourt
@@ -3487,20 +3293,15 @@
 4652;lille
 4653;lille-europe
 4654;livron
-4655;le locle
-4656;le locle
 4657;st-laurent—fouras
 4658;coullons
 4660;la madeleine
-4661;le mans
 4663;locminé
 4664;le monastier
-4665;limoux
 4666;lunéville
 4667;lanuejouls
 4668;longages—noé
 4670;lannemezan
-4671;montluçon
 4672;montluçon
 4673;longueville
 4674;lourches
@@ -3519,7 +3320,6 @@
 4690;lorient
 4691;lirey la chapelle
 4692;lury-sur-arnon
-4694;lusigny-sur-barse
 4695;lusigny-sur-barse rn19
 4696;lusigny-sur-barse centre
 4697;lison
@@ -3531,17 +3331,13 @@
 4704;les fontinettes
 4706;la chapelle-st-luc
 4707;lucé
-4708;ludon
 4710;lure
 4711;lutterbach
-4713;lalevade-d’ardèche
-4714;laval
 4715;longwy
 4716;st-lyé-la-forêt mairie
 4717;lyon gorge de loup
 4718;lyon
 4719;millau
-4720;meymac
 4721;meymac
 4722;miramas
 4723;marseille blancarde
@@ -3556,82 +3352,63 @@
 4737;melun
 4738;mende
 4740;mézidon
-4741;font-romeu
 4742;font-romeu ville
 4743;font-romeu-odeillo-via
 4744;magneux—courlandon
 4745;galimas
-4746;margaux
 4748;margut village
 4749;mesgrigny
 4750;mehun-sur-indre
 4751;mohon
 4752;chaumont hôpital
-4753;mulhouse
 4754;montluçon rimard
 4755;monsempron-libos
 4756;mâcon—loché tgv
 4757;marne-la-vallée—chessy
 4759;montmélian
 4760;mont-sur-meurthe
-4762;monnaie
 4764;le ménilot
 4766;mennessis
-4767;chaumont
 4768;chaumont quartier foch
 4769;chaumont
 4770;chaumont gendarmerie
 4771;marnaval église
 4773;marnay-sur-marne
-4774;moirans
 4775;mondoubleau station service
-4776;mondoubleau
 4778;mommenheim
 4779;molsheim
 4782;moret—veneux-les-sablons
 4784;motteville
 4785;aéroport marseille-provence bus
 4786;montpellier st-roch
-4787;paris montparnasse 3 vaugirard
 4788;morée salle des fêtes
-4789;margut
 4790;marseille
 4791;marseille st-charles
 4793;méreau
 4794;merrey
 4795;mouans-sartoux
-4796;moulis—listrac
 4797;mont-st-michel
-4798;masseret
 4800;moussey
 4802;gudmont centre
 4803;montdidier
 4804;mantes-la-jolie
 4805;montréjeau—gourdan-polignan
-4806;montélimar
 4807;montélimar
 4810;morteau
 4811;montereau
-4812;mont-sur-meurthe
 4813;montbazens
 4814;malaunay—le houlme
 4815;munster badischhof
-4816;munster
 4817;munster
-4819;marne-la-vallée
 4821;minversheim
 4822;morlaix
 4823;montieramey
 4824;magny-fouchard
 4825;méry-sur-cher
 4826;méry-sur-seine
-4827;metz
 4828;metz nord
 4829;castres
-4831;finhaut frontière
-4832;château-du-loir
 4833;st-benoît-la-forêt hôpital
-4834;benet
 4836;nice
 4837;nice st-augustin
 4838;nice riquier
@@ -3643,28 +3420,22 @@
 4846;niversac
 4847;novéant
 4848;neussargues
-4849;ferney
 4850;ingersheim
 4851;niherne—surins
 4853;niort
 4854;naves lycée agricole
 4855;nevers le banlay
 4856;fromentine—la barre-de-monts
-4857;nevers
 4858;nevers
 4859;noirmoutier-en-l’île
-4862;charbonnières-les-bains
 4863;nogent-sur-seine de gaulle
-4864;nogent-sur-seine
 4865;nogent-sur-seine théâtre
 4866;nantes
-4868;fronville
 4869;fronville mairie
 4870;naves
 4873;nexon
 4874;neuvy-pailloux bourg
 4875;montaulin mairie
-4876;aubenas
 4877;aubenas place de la paix
 4879;aubenas
 4881;obermodern
@@ -3672,11 +3443,9 @@
 4883;brignoles
 4884;st-maximin
 4885;forcalquier
-4888;orléans gare routière
 4889;orges
 4890;ostricourt
 4891;oissel
-4893;houlgate
 4894;orléans
 4895;le caoulet
 4896;le caoulet station
@@ -3705,15 +3474,12 @@
 4926;parthenay
 4927;largentière garage des rancs
 4929;pouzauges centre
-4930;port-bou
 4932;ker-lann
 4933;ahun
-4934;st-martial—le mont
 4935;fourneaux
 4936;st-quentin-la-tour
 4938;pontchâteau
 4940;port-de-bouc
-4941;montreuil-bellay
 4942;luz-st-sauveur
 4943;pontivy douric
 4945;pont-de-dore
@@ -3723,21 +3489,15 @@
 4949;st-joseph-le-castellas
 4951;pierrefitte-nestalas
 4952;le puy-en-velay lafayette
-4953;dives
 4954;dives-sur-mer—port-guillaume
 4955;perpignan
-4956;poitiers gare routière
-4957;périgueux
 4958;perrigny-sur-loire
 4959;phalsbourg
-4960;apach
-4963;privas
 4964;poitiers
 4966;les vans
 4967;pleumeur-bodou
 4970;ploërmel
 4971;paray-le-monial
-4972;pont-sur-seine
 4973;pont-sur-seine place st-martin
 4974;pont-sur-seine fleming
 4975;plouaret—trégor
@@ -3746,32 +3506,24 @@
 4980;pamiers
 4981;rouilly—st-loup la guérade
 4984;st-pierre-d’oléron
-4985;port-bou
 4986;port-bou
 4987;les portes-en-ré
 4988;epoisses
 4990;pontivy napoléon
 4992;pradons
 4993;pradelles
-4994;perros-guirec
 4998;portet—saint-simon
 4999;précy-sous-thil
 5000;pontarlier
-5001;poitiers
 5002;futuroscope
-5006;pau
 5007;pau ville
 5008;puyoô
-5009;le puy-en-velay
 5010;pont-la-ville
 5011;pont-l’évêque
-5012;capvern
 5013;capvern-les-bains
 5014;st-privat
-5015;parempuyre
 5016;pagny-sur-meuse
 5017;pyrénées-2000
-5018;pouzauges
 5019;le pouzin centre
 5021;aime-la-plagne
 5022;amiens
@@ -3784,7 +3536,6 @@
 5029;besançon
 5030;la courtine
 5031;moutier-rozeille
-5032;langres
 5033;langres la maladière
 5034;langres st-gilles
 5035;langres bel air
@@ -3794,7 +3545,6 @@
 5039;annemasse
 5041;mâcon
 5042;arras
-5043;château-renault
 5044;château-renault place jean jaurès
 5045;château-renault salle des fêtes
 5046;la valbonne
@@ -3804,29 +3554,22 @@
 5050;la villeneuve-au-chêne
 5053;st-andré-les-vergers reine blanche
 5054;bazancourt
-5055;rennes
 5060;rochefort
 5063;crancey rn
 5066;montrabé mairie
 5067;carignan rue de la paix
 5068;bridore
 5069;rodez
-5072;barberey
 5073;barberey centre commercial
 5074;ruffec (indre)
-5076;carignan
 5077;we
 5079;les granges
 5082;ria
-5083;azay-le-rideau
 5084;riom—châtel-guyon
 5085;la rochelle
 5086;la rochelle porte dauphine
-5087;rouilly—st-loup
 5088;rouilly—st-loup d21
-5089;crancey
 5090;rémilly
-5092;romilly-sur-seine
 5093;romilly-sur-seine atelier sncf
 5095;romilly-sur-seine hôpital
 5096;roanne
@@ -3836,7 +3579,6 @@
 5100;st-sébastien-sur-loire frêne rond
 5102;roocourt-la-côte
 5103;rivedoux jules ferry
-5104;sablanceaux
 5105;reipertswiller
 5106;serrières
 5107;rosporden
@@ -3845,25 +3587,18 @@
 5111;bruère-allichamps
 5112;rue
 5113;ruoms
-5114;dreux
 5115;dreux
-5116;villiers-le-sec
 5117;villiers-le-sec mairie
 5118;villiers-le-sec la poste
 5119;rouvray
 5120;la croix-blanche
 5122;royan
-5124;les moutiers-en-retz
-5125;cerizay
 5126;sablé-sur-sarthe
-5127;st-andré-les-vergers
 5129;st-antoine-de-ficalba
 5130;st-andré-le-gaz
 5131;bar-sur-aube hôpital
-5132;bar-sur-aube
 5133;bar-sur-aube piscine
 5134;salbris
-5135;st-amand-longpré
 5136;st-amand-longpré
 5137;sedan place calonne
 5138;st-amour
@@ -3884,9 +3619,7 @@
 5162;st-denis-près-martel
 5163;surdon
 5164;st-dizier hôpital
-5165;sedan
 5166;sedan
-5167;st-dizier
 5168;st-hilaire-le-château
 5169;seilhac
 5170;reims franchet d’esperey
@@ -3894,28 +3627,22 @@
 5172;serres place de la liberté
 5173;st-étienne-de-boulogne
 5174;cesson-sévigné
-5176;st-florentin hlm
 5178;st-georges-d’aurac
-5179;st-georges-d’aurac
 5180;st-genis-pouilly centre
 5181;st-germain-des-fossés
 5182;st-girons
 5183;st-agne
 5184;st-germain-au-mont-d’or
-5185;segré
 5186;segré centre
-5187;sogny-aux-moulins
 5188;auch le seilhan
 5189;sancerre
 5190;st-hilaire-sous-romilly
 5191;st-hilaire-au-temple
-5193;st-florentin
 5197;st-jean-de-losne
 5199;st-just-en-chaussée
 5200;st-julien-les-villas
-5201;marigny centre
+5201;marigny centre (manche)
 5202;santenay-les-bains
-5204;st-léonard-de-noblat
 5205;st-léonard-de-noblat ville
 5206;st-lô
 5207;sellières
@@ -3934,29 +3661,23 @@
 5227;soyons
 5228;st-pierre-d’albigny
 5229;ste-pazanne mairie
-5230;ste-pazanne
 5231;ste-pazanne
 5232;st-pol-sur-ternoise
 5234;serquigny
 5235;sarralbe
 5236;ars-en-ré
-5237;surins
 5238;st-roch
-5239;serres
 5241;st-savin
 5243;st-sulpice-laurière
 5244;st-sulpice
 5245;st-andré (nord)
 5246;ste-gemme
-5247;bâle st-jean
 5250;st-satur place du marché
 5251;sauveterre-de-béarn
 5254;séverac-le-château
-5256;st-valéry-en-caux
 5257;les forges-de-clairvaux
 5258;schweighouse-sur-moder
 5259;buswiller
-5260;strasbourg
 5261;cussy-les-forges
 5263;saincaize
 5266;gan
@@ -3964,21 +3685,14 @@
 5268;tassin
 5270;montaulin vallée verte
 5272;troyes boulevard du 14 juillet
-5273;bitche
-5274;château-gontier
 5275;château-gontier centre
 5276;tarascon-sur-rhône
-5277;enveitg
-5278;latour-de-carol
 5279;latour-de-carol – enveitg
 5280;bouziès
-5281;neuillé-pont-pierre
 5282;terrasson
 5283;tessonnières
-5285;torfou
 5288;tergnier
 5289;artigues (lot-et-garonne)
-5290;thiers
 5291;thiers mairie
 5292;thiers le moutier
 5293;thiers lycée
@@ -3987,7 +3701,6 @@
 5297;thoiry mairie
 5298;haute-picardie tgv
 5299;thouars
-5300;thoiry
 5304;toulon
 5306;toulouse
 5307;toulouse st-michel
@@ -3999,12 +3712,9 @@
 5314;troyes st-martin delaunay
 5315;le perrier
 5316;le cheminot
-5317;nantes
-5318;nantes centre
 5320;la trinité-sur-mer
 5321;trannes
 5322;toul
-5323;tournon centre
 5324;chatonrupt
 5326;troyes quennedey
 5327;trébeurden
@@ -4016,23 +3726,18 @@
 5334;troyes delestraint belgique
 5335;genève
 5336;genève cornavin
-5337;genève
-5338;tours
 5339;la tuque
 5341;troyes victor hugo
-5342;troyes
 5344;cirfontaines-en-azois
 5345;foulain rn19
 5346;vesaignes-sur-marne rn19
 5347;rolampont mairie
 5348;humes rn19
-5349;pierre-buffière
 5350;baziège village
 5351;la trivalle
 5354;st-girons capots
 5355;daudes
 5356;mazamet avenue de toulouse
-5357;toulouse gare routière
 5358;balma-gramont
 5359;beaupuy mairie
 5360;beaupuy clinique
@@ -4056,9 +3761,7 @@
 5378;lagarrigue la vitarelle
 5379;caucalières
 5380;st-alby centre
-5381;rodez centre
 5382;cayzac
-5383;millau gare routière
 5384;limite tarn d999
 5385;lauras
 5386;vabres-l’abbaye
@@ -4098,7 +3801,6 @@
 5422;graulhet place jourdain
 5423;briatexte
 5424;st-gauzens
-5425;st-sernin-lès-lavaure
 5427;lavaur tribunal
 5428;le ramel
 5429;verfeil—fenouille
@@ -4106,7 +3808,6 @@
 5431;lisle-sur-tarn place paul saissac
 5432;quimper
 5433;rabastens-de-bigorre centre
-5434;st-sulpice gare routière
 5435;l’huis-renaud
 5436;buzet
 5437;croix-de-pradel
@@ -4186,10 +3887,8 @@
 5519;capestang village
 5520;poilhes
 5521;montady
-5522;béziers gare routière
 5523;sauvian centre
 5524;sérignan centre
-5525;valras-plage
 5526;aucamville
 5527;fenouillet
 5528;st-alban rn 20
@@ -4215,7 +3914,6 @@
 5548;les pujols
 5549;tourtrol
 5550;coutens
-5551;gudmont
 5552;besset
 5553;aigues-vives (ariège)
 5554;toulouse la pointe
@@ -4258,34 +3956,23 @@
 5594;st-géry pont
 5596;la toulzanie
 5597;seuzac
-5598;urt
 5599;urt
 5601;rouen rive droite
-5602;rouen gare routière
 5603;rouen
-5604;aubusson
 5605;ussel
-5606;eurville
-5607;uzerche
 5608;uzer
 5609;ailleville
 5610;valence ville
 5611;valence
 5614;valence tgv
 5616;barbonvielle
-5617;vouciennes
 5618;vouecourt
 5619;le verdon centre
 5620;vendeuvre centre
-5621;le verdon
 5622;st-vaast-dieppedalle
 5623;val-de-reuil
-5625;vendeuvre
 5626;veynes—dévoluy
 5627;velluire centre
-5630;ventimiglia
-5633;vitry-le-françois office de tourisme
-5634;vitry-le-françois piscine
 5635;vignory centre
 5636;chauvigny
 5637;vendenheim
@@ -4301,63 +3988,41 @@
 5648;viviers la poste
 5649;bourg-st-andéol hôtel de ville
 5650;cruas centre
-5655;vitry-le-françois
-5656;blonville
-5657;villeneuve-st-georges
-5658;villedieu-les-poêles
 5660;vitrey-sur-mance
-5661;villers-sur-mer
 5663;vannes
 5664;st-pantaléon-les-vignes
 5665;vogue centre
 5666;volvic
-5667;la voulte
 5668;vallon-pont-d’arc
 5669;veyras
 5670;vaivre
-5671;ventimiglia frontière
-5672;vignory
-5673;vierzon
 5674;vierzon
-5675;viescamp-sous-jalles
 5676;ville-sous-la-ferté
 5677;vesseaux
 5678;vittel
 5679;venterol
-5680;vitry-la-ville
-5681;vitry-la-ville mairie
 5682;lavilledieu (ardèche)
 5683;ervy-le-châtel
-5684;ervy-le-châtel
 5685;vézelay
 5686;valaurie le colombier
 5687;davezieux
 5688;malataverne
 5689;taulignan
 5690;jessains
-5691;mirecourt
 5692;mirecourt lycée agricole
-5693;longuyon
 5694;longuyon pont entre deux eaux
 5695;longuyon la machine
 5696;longuyon collège
-5697;montmédy
 5698;montmédy centre
-5699;cons-la-grandville
 5700;cons-la-grandville lotissement
 5701;cons-la-grandville monument
-5702;longwy
-5703;longwy gare routière
-5704;creutzwald
 5705;creutzwald gare routière
-5706;sarrebourg
 5707;sarrebourg place mathey
 5708;sarrebourg zone industrielle
 5709;sarrebourg verreries
 5710;sarrebourg usine mephisto
 5711;wingen-sur-moder
 5713;vauchonvilliers
-5715;wissembourg
 5720;dives—cabourg
 5741;arsonval
 5742;abbeville
@@ -4386,7 +4051,6 @@
 5765;chalon-sur-saône
 5766;cerbère
 5767;chamonix mont blanc
-5768;cagnes-sur-mer
 5769;compiègne
 5770;la ciotat
 5771;collioure
@@ -4394,7 +4058,6 @@
 5773;châtellerault
 5774;château-thierry
 5775;charleville-mézières
-5776;dax
 5777;douai
 5778;évian-les-bains
 5779;épernay
@@ -4403,7 +4066,6 @@
 5782;guéret
 5783;st-gilles-croix-de-vie
 5784;hyères
-5785;hendaye
 5786;ste-feyre
 5788;st-jean-de-luz—ciboure
 5790;landerneau
@@ -4446,7 +4108,6 @@
 5828;sélestat
 5829;soissons
 5830;saintes
-5831;saumur
 5832;senlis
 5833;seclin
 5834;sète
@@ -4455,13 +4116,11 @@
 5837;st-claude
 5838;st-dié
 5839;thionville
-5840;tourcoing
 5841;tulle préfecture
 5842;villeneuve-sur-lot hôtel de ville
 5843;thonon-les-bains
 5844;tulle
 5845;auray
-5846;vendôme
 5847;villefranche-sur-saône
 5848;vienne
 5849;buxières-les-villiers
@@ -4486,11 +4145,8 @@
 5877;basel
 5878;basel sbb
 5880;hommarting tilleuls
-5881;arzviller fontaines
-5882;st-louis (moselle) plan incliné
 5883;guntzviller
 5884;berthelming mairie
-5890;zornhoff
 5892;london st-pancras
 5893;bruxelles-midi
 5894;amsterdam-centraal
@@ -4498,7 +4154,6 @@
 5903;tubize
 5904;lembeek
 5909;leuven
-5910;sterpenich
 5914;statte
 5915;welkenraedt
 5927;la louvière centre
@@ -4513,14 +4168,8 @@
 5940;menen
 5941;manage
 5945;brussels-airport-zaventem
-5950;blandain
 5953;froyennes
-5954;gouvy frontière
-5955;sterpenich frontière
-5956;visé frontière
 5964;antwerpen
-5965;antwerpen-oost
-5970;blandain ville
 5971;bruxelles-nord
 5973;brugge
 5974;bruxelles
@@ -4531,24 +4180,15 @@
 5998;oostende
 6000;mons
 6001;namur
-6003;quévy ville
-6005;schaerbeek
-6006;sterpenich ville
 6008;verviers-central
-6012;vallorbe
 6013;sarnen
 6014;maienfeld
-6015;saas-fee post
-6018;betten
 6019;campocologno
 6020;les verrières
 6021;domat/ems
 6024;jenaz
 6025;la-chaux-de-fonds
-6026;klosters-dorf
 6029;aarau
-6030;chene bourg
-6031;oberalppasshoehe—calmot
 6032;oberwald
 6036;poschiavo
 6037;le prese
@@ -4558,7 +4198,6 @@
 6044;schiers
 6046;stalden-saas
 6050;uzwil
-6052;tirano
 6053;trun
 6054;versam-safien
 6055;wil
@@ -4570,7 +4209,7 @@
 6062;les avants
 6064;montbovon
 6070;solothurn
-6071;montana vermala
+6071;crans montana gare
 6072;wildegg
 6073;bassecourt
 6074;wallisellen
@@ -4590,11 +4229,8 @@
 6093;baar
 6094;zürich oerlikon
 6095;courtelary
-6096;vernayaz
 6097;vernier
-6098;verbier poste
 6099;salgesch
-6100;la-plaine frontière
 6101;leissigen
 6103;travers
 6104;thun
@@ -4608,43 +4244,33 @@
 6116;münsterlingen-scherzingen
 6117;rorschach hafen
 6118;rorschach
-6120;courtetelle
+6120;courtételle
 6121;oberwinterthur
-6122;interlaken ost-o-west
 6124;bubikon
 6125;dottikon-dintikon
 6126;wetzikon
 6127;rivera-bironico
-6128;courtemaiche
+6128;courtemaîche
 6129;ausserberg
-6130;leuk
 6131;walchwil
 6132;gordola
-6133;riazzino-cugnasco
-6134;sant’antonio
 6135;tenero
 6136;melide
 6137;capolago—riva-san-vitale
 6138;trübbach
 6139;allaman
 6140;arbon
-6141;chiasso-o-iselle
 6142;goldach
 6144;mörschwil
 6145;altstätten sg
-6146;monthey
 6147;riddes
 6148;amriswil
-6149;luino
 6150;lyss
 6151;därligen
-6152;yvorne
 6153;gampel-steg
 6154;st-gallen—st-fiden
 6155;ardon
 6156;st-margrethen
-6157;les marécottes
-6159;les verrières ville
 6162;effretikon
 6164;puidoux-chexbres
 6165;martigny
@@ -4652,42 +4278,35 @@
 6169;courchavon
 6171;finhaut
 6172;la-neuveville
-6174;le chable
+6174;le châble
 6176;vallorbe
 6177;rheinfelden
 6178;pratteln
 6179;arth
-6181;villars
 6182;alp grüm
 6183;turtmann
-6184;le châtelard ville
 6185;flamatt
 6186;romanshorn
 6188;giubiasco
 6190;nyon
 6191;buix
 6195;langnau im emmental
-6197;fully
 6198;raron
 6199;bülach
 6200;murten
 6201;courfaivre
 6202;salvan
-6207;st-triphon
 6208;orsieres
 6210;payerne
-6211;roche
 6212;frauenfeld
 6217;pfäffikon sz
 6219;uster
-6220;greifensee
 6221;st-ursanne
 6222;wolhusen
 6223;zweisimmen
 6224;dübendorf
 6225;gossau sg
 6227;palézieux
-6228;schwerzenbach
 6230;zug bahnhof
 6231;satigny
 6234;saxon
@@ -4696,54 +4315,36 @@
 6238;evionnaz
 6239;rapperswil
 6241;sevelen
-6242;muri
-6243;räfis
 6244;othmarsingen
 6245;zürich hb
-6246;vernayaz
 6247;lausanne
 6248;grenchen nord
 6249;leukerbad
-6251;lausanne—ouchy
 6252;ste-croix
 6253;champéry
 6255;zürich enge
-6257;adelboden
 6259;bremgarten
 6262;champex lac
 6263;châtel-st-denis
-6264;flims-waldhaus-o-flims-dorf
 6265;gornergrat
 6266;grächen post
 6267;gryon
 6268;hergiswil
 6269;kleine-scheidegg
-6273;meiringen
-6274;monthey ville
-6275;saas-grund
 6277;st-luc poste
 6278;weggis
 6280;zinal poste
 6281;caux
-6282;les hauderes
-6283;mellingen
-6287;zurzach
 6288;le brassus
-6289;anzere
 6293;boncourt
 6294;burgdorf
-6297;brügg
+6297;brugg
 6299;braunwald
-6300;bern
+6300;bern hbf
 6302;chandolin poste
-6304;crans-sur-sierre
 6305;crans-sur-sierre poste
-6306;davos
 6307;davos platz
-6310;domodossola
 6311;dietikon
-6312;evian-les-bains port
-6314;evolene
 6315;faido
 6320;genève aéroport
 6321;glovelier
@@ -4755,55 +4356,32 @@
 6332;gruyères
 6333;haute-nendaz village
 6335;interlaken west
-6338;klosters
 6345;lugano
-6346;lenzerheide/lai
 6347;morgins poste
-6348;monthey
 6349;neuchâtel
-6350;neuchâtel
-6351;neuchâtel
 6352;st-gallen
 6353;luzern
-6354;lausanne
 6355;arolla poste
-6356;rorschach
-6358;st-gallen
-6359;sion
 6360;st-moritz
 6361;troistorrents
-6363;veysonnaz
-6364;veysonnaz village
 6365;villars-sur-ollon
 6366;vissoie poste
-6367;vallorbe
-6368;winthertur
-6370;les marécottes
-6371;finhaut
-6372;aigle
 6374;biel/bienne
-6375;brigue
-6376;buchs
-6377;chiasso
 6378;chur
 6379;delémont
 6380;einsiedeln
 6382;fribourg
 6386;langenthal
-6387;genève
 6388;spiez
 6389;les diablerets
-6391;martigny
 6392;montreux
 6393;olten
 6395;schaffhausen
-6396;sierre
 6399;porrentruy
 6400;anzere poste
 6401;zürich
 6403;interlaken
 6404;tortosa
-6405;manzanares-soto el real
 6406;el arahal
 6407;pinos puente
 6408;albacete-los llanos
@@ -4812,38 +4390,27 @@
 6411;osuna
 6412;gudillos
 6413;pedrera
-6414;estepar
-6415;quintanilleja
 6416;loja
 6417;loja – san francisco
 6418;navas de riofrío – la losa
-6419;villanueva de tapia
 6420;archidona
-6421;el pinar
-6422;camorritos
-6423;la maya y fresno
 6424;antequera ciudad
-6425;puerto de navacerrada
 6426;calamocha nueva
 6427;bembibre
-6428;los cotos
 6429;toral de los vados
 6430;san clodio-quiroga
 6431;las matas
 6432;vega magaz
 6433;valladolid campo grande
-6434;ciruelos
 6435;briviesca
 6436;vitoria – gasteiz
 6437;zumárraga
 6438;linares-congostinas
-6439;irún
 6440;villanueva del rio y minas
 6441;alcolea del rio
 6442;pola de lena
 6443;palencia
 6444;sahagún
-6445;riaza
 6446;lerma
 6447;villalba de guadarrama
 6448;reinosa
@@ -4855,7 +4422,6 @@
 6454;alegria de alava-dulantzi
 6455;oviedo
 6456;salvatierra de álava
-6458;valcabado
 6459;guitiriz
 6460;olazagutia
 6461;guarnizo
@@ -4864,13 +4430,11 @@
 6464;ourense-empalme
 6465;salvaterra de miño
 6466;herradon – la cañada
-6467;navalgrande
 6468;guimorcondo
 6469;zegama – otzaurte
 6470;zamora
 6471;o irixo
 6472;pobra de san xián
-6473;lajosa
 6474;toledo
 6475;rabade
 6476;bandeira
@@ -4881,25 +4445,13 @@
 6481;teixeiro
 6482;curtis
 6483;valencia de alcántara
-6484;sestao-urbinaga
-6485;ormaiztegui
 6486;mingorria
-6487;velayos
 6488;sanchidrian
-6489;londoño
 6490;adanero (muñoz)
-6491;medellín
-6492;aranda de duero-montecillo
 6493;segovia estación
 6494;guareña
-6495;ataquines
-6496;gómeznarro
-6497;alcolea de córdoba
-6498;fuentes de onoro
 6499;manzanares
 6500;matapozuelos
-6501;san julián de musques
-6502;hernani
 6503;pasaia
 6504;montilla
 6505;puente genil estación
@@ -4907,7 +4459,6 @@
 6507;ronda
 6508;san roque – la línea
 6509;moreda
-6510;valencia de alcántara
 6511;cabezón del pisuerga
 6512;la encina
 6513;irún
@@ -4917,8 +4468,6 @@
 6517;los rosales
 6518;calatorao
 6519;la rinconada
-6520;bonete
-6521;alpera
 6522;grisen
 6523;prat de llobregat
 6524;montcada i reixac – manresa
@@ -4926,25 +4475,14 @@
 6526;lleida
 6527;maçanet – massanes
 6528;llançà
-6529;san vicente de calders
-6530;utebo
 6531;santiago de compostela
 6532;sevilla san bernardo
 6533;caudete
 6534;villena
 6535;sax
-6536;elda petrer
-6537;monovar pinoso
 6538;novelda aspe
-6539;monforte del cid
-6540;agost
-6541;san vicente de raspeig
 6542;sant vicenç de calders
 6543;villaverde bajo
-6544;pedro abad
-6545;manzanares
-6546;orense
-6547;sevilla plaza de armas
 6548;algeciras
 6549;sagunt
 6550;sabadell sud
@@ -4952,20 +4490,15 @@
 6552;antequera santa ana
 6553;mérida
 6554;mataró
-6555;malgrat
 6556;logroño
-6557;la molina
 6558;jaca
 6559;huesca
 6560;huelva
 6561;gijón-sanz crespo
 6562;elx parc
-6563;cullera
 6564;cartagena
 6565;cambrils
-6566;benicasim
 6567;canfranc
-6568;sevilla santa justa
 6569;águilas
 6570;málaga-maría zambrano
 6571;avilés
@@ -4974,8 +4507,6 @@
 6574;gandía
 6575;guillarei
 6576;manresa
-6577;orihuela-miguel hernández
-6578;pineda
 6579;pontevedra
 6580;puertollano
 6581;santander estación
@@ -4983,32 +4514,21 @@
 6583;torrelavega
 6584;tudela de navarra
 6585;utrera
-6586;valencia de alcántara frontera
-6587;el vendrell
 6588;caspe
-6589;melilla
 6590;sarria
 6591;jerez de la frontera
 6592;puerto de santa maría
 6593;vilanova i la geltrú
 6594;calasparra
-6595;burriana-alquerías del niño perdido
 6596;guadalajara
-6597;arenys de mar
 6598;ferrol
 6599;betanzos-cidade
 6600;reus
-6601;vic
 6602;alacant-terminal
 6603;aguilar de la frontera
-6604;algeciras
-6605;algeciras puerto
 6606;almería
 6607;alsasua
-6608;andorre
-6609;arévalo
 6610;la garrovilla
-6611;arbos
 6612;corcos-aguilarejo
 6613;astorga
 6614;ávila
@@ -5025,10 +4545,8 @@
 6625;barcelona sants
 6626;barcelona estació de frança
 6627;burgos
-6628;bustarviejo-valdemanco
 6629;cádiz
 6630;cáceres
-6631;canfranc
 6632;calella
 6633;caldas de malavella
 6634;cantalapiedra
@@ -5042,19 +4560,16 @@
 6642;san sebastián-donostia
 6643;torrelodones
 6644;viana
-6645;fuentes de onoro
 6646;fuentes de oñoro
 6647;fuengirola
 6648;figueres
 6649;fuente de san esteban boadilla
 6650;flassa
-6651;gascones-buitrago
 6652;guadix
 6653;brenes
 6654;granollers centro
 6655;gerona
 6656;granada
-6657;irún
 6658;jaén
 6659;a coruña-san cristovo
 6660;león
@@ -5062,8 +4577,6 @@
 6662;valdestillas
 6663;madrid
 6664;madrid príncipe pio
-6665;madrid vallecas
-6666;madrid villaverde
 6667;madrid atocha
 6668;madrid chamartín
 6669;medina del campo estación
@@ -5071,34 +4584,27 @@
 6671;murcia
 6672;cordoba
 6673;port aventura
-6674;plasencia ciudad
 6675;pamplona/iruña
-6676;port-bou
 6677;tarragona estació
-6678;ribas de freser
 6679;redondela de galicia
-6680;las rosas
 6681;san fernando de cádiz
 6682;salamanca
 6683;sevilla
 6684;camp tarragona
 6685;torremolinos
 6686;tui
-6687;valencia de alcantar
 6688;venta de baños
 6689;vigo
 6690;valencia estaciò nord
 6691;bad driburg (westf)
 6692;beratzhausen
 6693;bienenbüttel
-6694;bitburg
 6695;blankenheim (wald)
 6696;bodenheim
 6697;neckarsulm
 6698;aachen
 6699;aachen-rothe erde
 6700;aachen hbf
-6701;aachen süd (gr)
 6702;aachen west
 6703;buxtehude
 6704;ebelsbach-eltmann
@@ -5117,14 +4623,11 @@
 6717;hennef (sieg)
 6718;herrenberg
 6719;hochstadt-marktzeuln
-6720;hoexter
 6721;leese-stolzenau
-6722;kaltenbrunn oberbay
 6723;landau (isar)
 6725;mechernich
 6726;aschaffenburg hbf
 6727;allensbach
-6728;morsum bahnhof
 6729;munster (örtze)
 6730;nackenheim
 6731;neustadt (kr marburg)
@@ -5157,7 +4660,6 @@
 6758;zeil
 6759;werl
 6760;winningen (mosel)
-6761;aitrang
 6762;alfeld (leine)
 6763;altena (westf)
 6764;altenstadt (iller)
@@ -5180,7 +4682,6 @@
 6781;assmannshausen
 6782;lennestadt-altenhundem
 6783;altenau (bay)
-6784;altenwalde
 6785;bredstedt
 6787;bacharach
 6788;bad ems
@@ -5194,7 +4695,6 @@
 6796;bad pyrmont
 6797;bad reichenhall
 6798;bad reichenhall-kirchberg
-6799;bad salzig kd
 6800;bad salzuflen
 6801;bad sooden-allendorf
 6802;bad teinach-neubulach
@@ -5212,7 +4712,6 @@
 6814;biberach (baden)
 6815;biberach (riß)
 6816;bad wildungen
-6817;bingerbrueck
 6818;birkenfeld (enz)
 6819;bischofswiesen
 6820;blaichach (allgäu)
@@ -5229,7 +4728,6 @@
 6832;burgsinn
 6833;betzdorf (sieg)
 6834;bremerhaven-lehe
-6835;bremerhaven-columbusbahnhof
 6836;bad friedrichshall-jagstfeld
 6837;leun/braunfels
 6838;bad münder (deister)
@@ -5266,7 +4764,6 @@
 6870;dornstetten
 6871;eckernförde
 6872;eichstätt bahnhof
-6873;eimelrod
 6874;elfershausen-trimberg
 6875;bad bevensen
 6876;elmshorn
@@ -5335,16 +4832,13 @@
 6941;goch
 6942;bordesholm
 6943;frankfurt (m) flughafen
-6944;hannover wuelf messe
 6945;haffkrug
-6946;hallthurm
 6947;haltern am see
 6948;hameln
 6949;hammelburg
 6950;hammerau
 6951;hannover-kleefeld
 6952;haßfurt
-6953;hannover lind hafen
 6954;hegne
 6955;heide (holst)
 6956;hann münden
@@ -5355,7 +4849,6 @@
 6961;herzogenrath
 6962;hildesheim hbf
 6963;hinterzarten
-6964;hirschau
 6965;höfen (enz) bf
 6966;hörstel
 6967;hochspeyer
@@ -5371,7 +4864,6 @@
 6977;hochdorf (b horb)
 6978;himmelreich
 6979;kobern-gondorf
-6980;himmighausen
 6981;siegen-weidenau
 6982;husum
 6983;hergatz
@@ -5386,7 +4878,6 @@
 6992;passau hbf
 6993;jever
 6994;salzburg
-6995;jodbad sulzbrunn
 6996;klanxbüll
 6997;jossa
 6998;jübek
@@ -5410,12 +4901,10 @@
 7016;kaub
 7017;königswinter
 7018;kamen
-7019;köln kalk
 7020;königshofen (baden)
 7021;köln süd
 7022;köln-ehrenfeld
 7023;korbach
-7024;kranenburg
 7025;klingenberg (main)
 7026;kressbronn
 7027;kirchenlamitz ost
@@ -5521,7 +5010,6 @@
 7129;neubrücke (nahe)
 7130;neuenbürg (enz)
 7131;neuenburg (baden)
-7132;neuenreuth creu
 7133;neufahrn (niederbay)
 7134;neuhof (kr fulda)
 7135;nesselwang
@@ -5582,7 +5070,6 @@
 7191;übach-palenberg
 7192;papenburg (ems)
 7193;parsberg
-7194;peterzell koenigsfld
 7195;peine
 7196;piding
 7197;gummersbach
@@ -5638,7 +5125,6 @@
 7248;schenkenzell
 7249;rockenhausen
 7250;schiltach
-7251;rueckstetten
 7252;runkel
 7253;saarburg (bz trier)
 7254;saarlouis hbf
@@ -5660,7 +5146,6 @@
 7270;schifferstadt
 7271;schleswig
 7272;scherfede
-7273;schoeningen
 7274;schönmünzach
 7275;schondorf (bay)
 7276;schorndorf
@@ -5681,7 +5166,6 @@
 7291;siegen
 7292;singen (hohentwiel)
 7293;bad sobernheim
-7294;solingen ohligs
 7295;soest
 7296;sontheim-brenz
 7297;solingen hbf
@@ -5712,7 +5196,6 @@
 7322;seckach
 7323;stadtprozelten
 7324;schwarzenfeld (opf)
-7325;spieka
 7326;süderbrarup
 7327;sinsheim (elsenz) hbf
 7328;teisendorf
@@ -5728,19 +5211,16 @@
 7338;troisdorf
 7339;tuttlingen
 7340;tauberbischofsheim
-7341;timmdorf
 7342;tarp
 7343;tübingen hbf
 7344;untergrainau
 7345;trebgast
-7346;tutting
 7347;überlingen
 7348;übersee
 7349;uelzen
 7350;usseln
 7351;unterreichenbach
 7352;unterammergau
-7353;unterbalbach
 7354;unterlüß
 7355;vaihingen (enz)
 7356;varel (oldb)
@@ -5752,7 +5232,6 @@
 7362;völklingen
 7363;vechelde
 7364;lunden
-7365;ulrichsberg
 7366;pocking
 7367;kevelaer
 7368;sulzbach (inn)
@@ -5762,7 +5241,6 @@
 7372;wabern (bz kassel)
 7373;wächtersbach
 7374;waiblingen
-7375;waldeck
 7376;waldshut
 7377;wanne-eickel hbf
 7378;warburg (westf)
@@ -5783,14 +5261,12 @@
 7394;wiesau (oberpf)
 7395;basel badischer bahnhof
 7396;bad wildbad bf
-7397;wilhelmshaven hbf
 7398;bonn-beuel
 7399;willebadessen
 7400;bonn-bad godesberg
 7401;willingen
 7402;winsen (luhe)
 7403;wissen (sieg)
-7404;winklarn
 7405;witten hbf
 7406;wittmund
 7407;witzenhausen nord
@@ -5821,12 +5297,10 @@
 7432;werdohl
 7433;zweibrücken hbf
 7434;zwiesel (bay)
-7435;zollhaus
 7436;hedemünden
 7437;friedland (han)
 7438;bobingen
 7439;bad aibling
-7440;eggebek
 7441;flensburg-weiche
 7442;bad oldesloe
 7443;bad wörishofen
@@ -5849,8 +5323,6 @@
 7460;igel
 7461;leutkirch
 7462;barnten
-7463;baddeckenstedt
-7464;othfresen
 7465;herbolzheim (breisg)
 7466;emmendingen
 7467;raisdorf
@@ -5862,8 +5334,6 @@
 7473;bonn hbf
 7474;hamburg hbf
 7475;düsseldorf hbf
-7476;lindau reutin
-7477;mittenwald (gr)
 7478;mannheim
 7479;mannheim hbf
 7480;münchen hbf
@@ -5871,9 +5341,6 @@
 7482;neustadt (weinstr) hbf
 7483;wuppertal
 7484;wuppertal hbf
-7485;buebingen
-7486;puttgarden (ms)
-7487;wengerohr
 7488;altötting
 7489;bad homburg
 7490;balingen (württ)
@@ -5916,7 +5383,6 @@
 7527;berlin
 7528;berlin südkreuz
 7529;bietigheim-bissingen
-7530;bitburg
 7531;bückeburg
 7532;backnang
 7533;bad kreuznach
@@ -5937,7 +5403,6 @@
 7548;bremen hbf
 7549;bensheim
 7550;berlin-spandau
-7551;brunswick
 7552;bretten
 7553;bad oeynhausen
 7554;bayreuth hbf
@@ -5976,7 +5441,6 @@
 7587;engen
 7588;erfurt hbf
 7589;erkelenz
-7590;esslingen-am-neckar
 7591;essen hbf
 7592;fürth (bay) hbf
 7593;plauen (vogtl) ob bf
@@ -6005,7 +5469,6 @@
 7617;geisenheim
 7618;gütersloh hbf
 7619;geislingen (steige)
-7620;gutach schwarzwaldb
 7621;baunatal-guntershausen
 7622;günzburg
 7623;hannover
@@ -6019,7 +5482,6 @@
 7631;heilbronn hbf
 7632;heidelberg
 7633;heidelberg hbf
-7634;hersbruck (pegnitz)
 7635;hersbruck (r pegnitz)
 7636;herford
 7637;heigenbrücken
@@ -6044,7 +5506,6 @@
 7656;kempten (allgäu) hbf
 7657;kaufbeuren
 7658;karlsruhe-durlach
-7659;kehl
 7660;krefeld
 7661;krefeld hbf
 7662;kirchhain (bz kassel)
@@ -6058,7 +5519,6 @@
 7670;kreiensen
 7671;kassel hbf
 7672;karlstadt (main)
-7673;konstanz
 7674;konstanz
 7675;kitzingen
 7676;lübeck hbf
@@ -6070,7 +5530,6 @@
 7682;marktredwitz
 7683;münchen ost
 7684;münchen-pasing
-7685;mittenwald
 7686;münchen
 7687;münster (westf) hbf
 7688;neuburg (donau)
@@ -6079,9 +5538,7 @@
 7691;nürnberg hbf
 7692;freiburg (breisgau)
 7693;oschatz
-7694;pfronten
 7695;pforzheim
-7696;puttgarden
 7697;puttgarden
 7698;pegnitz
 7699;mayen ost
@@ -6089,7 +5546,6 @@
 7701;würzburg hbf
 7702;radolfzell
 7703;rastatt
-7704;bad-reichenhall
 7705;remscheid
 7706;ribnitz-damgarten west
 7707;salzgitter
@@ -6098,7 +5554,6 @@
 7710;stuttgart hbf
 7711;solingen
 7712;schnabelwaid
-7713;sulzbach rosenberg
 7714;stuttgart
 7715;schweinfurt
 7716;tantow
@@ -6108,7 +5563,6 @@
 7720;berlin wannsee
 7721;wiesbaden
 7722;potsdam
-7723;potsdam stadt
 7724;potsdam hbf
 7725;arenshausen
 7726;baden-baden
@@ -6232,7 +5686,6 @@
 7845;llandudno junction
 7846;long eaton
 7847;loughborough
-7848;luton
 7849;macclesfield
 7850;oxenholme lake district
 7851;prestatyn
@@ -6244,14 +5697,12 @@
 7857;water orton
 7858;watford junction
 7859;wigan north western
-7860;devils bridge
 7861;annan
 7862;ayr station
 7863;blair atholl
 7864;carrbridge
 7865;carstairs
 7866;dalwhinnie
-7867;lincoln-st-marks
 7868;haymarket (edinburgh)
 7869;kingussie
 7870;kirkconnel
@@ -6287,7 +5738,6 @@
 7900;dorchester south
 7901;clapham junction
 7902;east croydon
-7903;folkestone harbour
 7904;cardiff bay
 7905;haverfordwest
 7906;severn tunnel junction
@@ -6352,7 +5802,6 @@
 7965;worcester foregate street
 7966;whimple
 7967;andover
-7968;ashford international
 7969;harlech
 7970;tisbury
 7971;minffordd
@@ -6370,7 +5819,6 @@
 7983;runcorn east
 7984;bishops stortford
 7985;bury st edmunds
-7986;dover eastern docks
 7987;stowmarket
 7988;chelmsford
 7989;colchester station
@@ -6419,10 +5867,8 @@
 8032;romsey
 8033;corrour
 8034;polmont
-8035;dover hoverport
 8036;dalmally
 8037;dumbarton central
-8038;weymouth quay
 8039;haslemere
 8040;cark
 8041;hunts cross
@@ -6511,17 +5957,13 @@
 8124;church & oswaldtwistle
 8125;colne
 8126;derker metrolink
-8127;failsworth metrolink
 8128;farnworth
 8129;hindley
-8130;hollinwood metrolink
 8131;kearsley
 8132;leyland
 8133;milnrow metrolink
 8134;moses gate
 8135;nelson
-8136;oldham mumps metrolink
-8137;oldham werneth
 8138;rishton
 8139;shaw & crompton metrolink
 8140;westhoughton
@@ -6529,21 +5971,16 @@
 8142;lewes
 8143;folkestone central
 8144;aberdeen
-8145;gatwick—airport
 8146;eastbourne
-8147;fishguard harbour
 8148;rochester
 8149;st ives
 8150;stratford-upon-avon station
 8151;tunbridge wells
 8152;belfast central
 8153;arbroath
-8154;ashford
 8155;ashford international
 8156;aberystwyth
-8157;london st-pancras
 8158;tilbury town
-8159;larne
 8160;snowdown
 8161;littlehampton
 8162;maidstone east
@@ -6567,7 +6004,6 @@
 8180;bristol parkway
 8181;bridgend
 8182;bristol temple meads
-8183;bristol
 8184;brighton
 8185;bridgwater
 8186;basingstoke
@@ -6591,7 +6027,6 @@
 8204;cleethorpes
 8205;clacton-on-sea
 8206;chester
-8207;cardiff
 8208;darlington
 8209;dunbar
 8210;derby
@@ -6600,8 +6035,6 @@
 8213;didcot parkway
 8214;gatwick airport
 8215;doncaster
-8216;dover
-8217;dover western docks
 8218;tamworth
 8219;penrhyndeudraeth
 8220;dundee
@@ -6615,8 +6048,6 @@
 8228;exeter
 8229;folkestone
 8230;fort william
-8231;gatwick
-8232;gatwick airport
 8233;gloucester
 8234;glasgow
 8235;glasgow queen street
@@ -6627,7 +6058,6 @@
 8240;grimsby town
 8241;huddersfield
 8242;halifax
-8243;hull
 8244;holyhead
 8245;herne bay
 8246;hereford
@@ -6635,11 +6065,9 @@
 8248;hastings
 8249;hartlepool
 8250;heathrow terminals 1-2-3 rail
-8251;harwich international
 8252;hayle
 8253;ipswich station
 8254;inverness
-8255;jersey
 8256;kirkcaldy
 8257;kilmarnock
 8258;kyle of lochalsh
@@ -6655,7 +6083,6 @@
 8268;london marylebone
 8269;london victoria
 8270;london waterloo
-8271;london southern railway
 8272;stratford international
 8273;london fenchurch street
 8274;london paddington
@@ -6745,7 +6172,6 @@
 8358;nuneaton
 8359;newport gwent
 8360;oxford
-8361;gde bretagne
 8362;peterborough
 8363;plymouth
 8364;preston
@@ -6763,34 +6189,27 @@
 8376;swansea
 8377;swindon
 8378;thurso
-8379;hull
-8380;weymouth
 8381;woking (main)
 8382;whitstable
 8383;wolverhampton
-8384;gatwick
 8385;heathrow airport
-8386;london city airport
 8387;york
 8427;firenze campo di marte
 8433;firenze
 8434;firenze santa maria novella
 8435;firenze rifredi
-8441;montevarchi terranova
+8441;montevarchi-terranuova
 8442;genova brignole
 8450;genova
 8453;genova piazza principe
 8455;genova quinto al mare
-8477;limone
 8483;milano
-8484;milano bovisa
 8485;milano lambrate
 8490;milano centrale
 8491;milano rogoredo
 8492;milano porta garibaldi
 8493;modena
 8497;napoli centrale
-8500;napoli marittima
 8509;oulx-cesana-clavière-sestrières
 8514;parma
 8524;brescia
@@ -6811,21 +6230,13 @@
 8575;venezia mestre
 8576;venezia carpenedo
 8578;ventimiglia
-8580;verona
 8581;verona porta nuova
-8583;verona cadidavid
-8585;ventimiglia
 8589;mersch
 8590;troisvierges
-8591;wasserbillig frontière
-8592;wasserbillig
-8593;esch-sur-alzette
 8594;differdange
 8595;wiltz
 8596;dudelange-ville
 8597;diekirch
-8599;rodange
-8600;bettembourg
 8603;kautenbach
 8604;luxembourg
 8605;pétange
@@ -6834,14 +6245,11 @@
 8608;almelo
 8609;amsterdam sloterdijk
 8610;apeldoorn
-8611;amsterdam de vlugtlaan
 8615;delft
 8616;deventer
-8617;ede wageningen
 8619;gouda
 8620;groningen
 8621;den helder
-8623;hengelo
 8624;hilversum
 8626;hoofddorp
 8627;leiden centraal
@@ -6856,15 +6264,9 @@
 8643;amsterdam amstel
 8644;den haag hs
 8645;zwolle
-8646;zutphen
-8647;oss
 8648;leeuwarden
-8649;heerlen
-8650;heerenveen
 8651;enschede
-8652;bergen op zoom
 8653;assen
-8656;any dutch station
 8657;amsterdam
 8658;amersfoort
 8659;arnhem
@@ -6872,7 +6274,6 @@
 8662;dordrecht
 8663;den haag
 8664;den haag centraal
-8665;eijsden maastricht grens
 8666;eindhoven
 8667;haarlem
 8668;maastricht
@@ -6880,1709 +6281,133 @@
 8670;rotterdam centraal
 8672;schiphol airport
 8673;utrecht centraal
-8674;pinhel
 8675;vila franca das naves
 8676;mangualde
 8677;santa comba dão
-8678;luso buçaco
 8679;pombal
-8680;santarém
 8681;pampilhosa
 8682;nelas
-8683;ovar
-8684;cerdeira
 8685;viana do castelo
 8686;abrantes
-8687;torre
-8688;marvão beira
-8689;figueira da foz
 8690;caldas da rainha
-8691;gaia
-8692;gouveia
 8693;fátima
-8694;marvão beira
-8695;vila nova de gaia
 8696;lisboa santa apolónia
 8697;porto campanhã
 8698;barcelos
 8699;fundão
 8700;lagos
-8701;lisboa terreiro do paço
-8702;portimão
-8703;vila real de san antónio guad
 8704;beja
 8705;valença
-8706;valença
 8707;celorico da beira
-8708;leiria
-8709;aveiro
-8710;braga
-8711;coimbra
-8712;castelo branco
-8713;cacem
-8714;covilhã
-8715;espinho
-8716;entroncamento
-8717;estarreja
 8718;faro
-8719;fátima
 8720;guarda
 8721;lisboa
 8722;lisboa oriente
 8723;nine
-8724;pocinho
-8725;régua
-8726;tua
-8727;tunes
 8728;torres vedras
 8729;vilar formoso
-8731;luxembourg
-8732;auxon rn
-8735;st-lyé libération
 8737;aéroport de beauvais-tillé
 8738;breteuil rn
-8740;breteuil place laffitte
 8745;st-dizier st-amand
-8746;audun-le-roman hotel de ville
-8747;barisey-la-côte mairie
-8748;gerbeviller gambetta
-8749;lexy
 8750;lexy rue du square
 8754;lunéville diettmann
-8756;magnières lotissement
-8757;bénestroff centre
 8759;bitche rue de la paix
-8763;bouzonville rue alzing
 8765;distroff église
-8768;ébersviller centre
-8771;enchenberg carrefour
-8772;enchenberg mairie
-8773;farébersviller cité
 8775;faréberswiller moulin
-8777;farschviller centre
-8779;fénétrange carrefour étang
-8780;fénétrange gendarmerie
-8781;fénétrange pensionnat
-8783;hombourg-budange chapelle
-8784;hombourg-budange tilleuls
-8788;kédange église
-8791;kuntzig bibiche
-8794;kuntzig place de la liberté
-8797;morhange jeanne d’arc
-8800;morhange place de la république
-8802;philippsbourg liesbach
-8804;rohrbach-lès-bitche
-8806;sarralbe hôtel de ville
-8807;sarraltroff poste
-8808;sarraltroff mairie
 8811;écouché centre
-8813;le merlerault centre
-8814;angers centre
 8816;angers université
-8817;le lion-d’angers
-8818;ancenis aeropole
-8819;pontchâteau landas
 8821;cormery place du croissant
 8822;reignac café brulé
-8824;lunery église
-8827;limoges winston churchill
 8828;felletin école métiers
 8829;lancey
-8830;rosiers-d’égletons
-8831;maussac le poteau
 8832;tulle cité administrative
 8834;ussel ville
 8835;agen lycée palissy
-8836;casteljaloux entrée
-8837;casteljaloux hlm
-8838;casteljaloux la poste
-8839;casteljaloux lac claren
-8840;fumel place gambetta
-8841;fumel usine
 8842;dax hôpital
-8845;pau boulevard barbanègre
-8846;baraqueville place
-8847;bertholène café girou
-8848;capdenac clayrou
-8849;capdenac port
 8850;decazeville place wilson
 8851;decazeville cité combettes
 8852;decazeville cité la vitarelle
-8854;gages relais
-8855;laissac place du foirail
-8856;laissac greze embranchement
-8857;naucelle centre
-8858;rodez quatre saisons
-8859;rodez victor hugo
 8861;albas rivière basse
-8862;albas rivière haute
-8863;cahors place des consuls
 8865;cahors regourd
 8867;douelle cessac
 8868;douelle les bories
-8869;duravel place du foirail
 8870;gramat ville
-8871;luzech foyer
 8873;luzech institut boissor
 8874;luzech place de la mairie
 8875;montbrun mas-de-doucet
 8876;prayssac hospice
 8878;puy-l’évêque place rampeau
 8879;puy-l’évêque place platane
-8880;touzac pont
-8881;albias abri bus
-8882;grisolles caserne des pompiers
-8883;réalville place
-8884;carmaux gambetta
 8885;labruguière abri bus
 8886;lavaur centre
-8888;marssac-sur-tarn rn 88
-8889;mazamet avenue du maréchal juin
-8891;tanus centre
-8892;aubiet crédit agricole
 8893;fleurance gendarmerie
-8894;l’isle-jourdain caserne
 8895;miélan ville
-8896;foix centre
-8897;mérens-les-vals village
-8898;pamiers centre
-8899;varilhes centre
-8900;avignonet mairie
-8901;capens la girouette
-8902;muret débat
-8903;pibrac rond point faïencerie
 8904;revel lep
-8906;argèles-gazost cordée
-8907;bordes pn 147
-8908;capvern le laca
-8909;capvern mairie
-8910;lannemezan centre
-8911;tarbes gare routière
-8912;tournay centre
 8914;mauriac lycée cortat
-8915;riom-es-montagnes clinique
-8918;dunières ville
-8919;la chaise-dieu mairie
 8920;le puy-en-velay l’hermitage
-8921;le puy-en-velay fayolle
 8922;paulhaguet monument
-8923;bourg-lastic place de la poste
 8924;brassac-les-mines—ste-florine lycée rabelais
-8925;clermont-ferrand
 8926;issoire lycée deville
 8927;issoire lycée murat
 8928;le breuil-sur-couze lycée
 8929;le breuil-sur-couze salle des fêtes
-8930;lezoux mairie
 8931;pont-de-dore le chambon
-8932;pont-du-château carrefour
-8933;pont-du-château croix blanche
-8935;pontmort rn
 8936;puy-guillaume ville
 8937;puy-guillaume la roche
-8938;ris abri bus
-8940;montluçon lem
-8941;bessay hôtel
 8943;st-yorre croix des vernes
 8944;st-yorre nouvel hôtel
-8945;urçay hôtel du lion d’or
-8946;varennes-sur-allier mairie
 8948;nevers les perrières
-8949;cordesse—igornay centre
-8952;digoin lycée
-8953;le creusot lycée jaurès
 8954;roanne arsenal
-8955;alba ruines romaines
 8956;villeneuve-de-berg pommiers
-8957;poule mairie
-8958;ternay barbières
 8959;chamonix aiguille du midi
 8960;le valdahon camp militaire
-8961;gray gare routière
-8964;cornimont perception
-8965;cornimont hôpital rural
-8966;cornimont lansauchamp
-8967;darnieulles station service
-8968;dompaire route de mirecourt
-8969;fresse la hardoye
-8970;hielle—lépange
-8971;le thillot place de la république
-8972;mattaincourt rue du général de gaulle
-8973;mattaincourt manufacture vosgienne de meubles
-8974;rambervillers-lunéville
-8976;rambervillers rue henry boucher
-8977;rambervillers avenue du 11 novembre
 8979;remiremont magdelaine
-8980;roville-aux-chênes lycée
-8981;rupt-sur-moselle—saulx
-8983;gundershoffen au cygne
-8984;keskastel abri
-8985;keskastel restaurant au kastel
-8986;niederbronn maison de l’archéologie
-8987;niederbronn usine
-8988;niederbronn centre
-8991;sarrewerden lotissement
-8992;schweighouse-sur-moder au faubourg
-8993;guiscriff cinq chemins
-8994;pontivy place du souvenir
-8995;carhaix lycée
-8996;carhaix lycée diwan
 8997;carhaix république
-8998;kernevel centre
-9000;morlaix lycée corbière
-9001;la motte centre
-9002;plaintel échangeur
-9003;plaintel malakof
-9004;quintin la vallée
-9006;lescar
-9007;albas
-9008;le canet
-9009;poey
-9010;st-barthélémy
-9011;lacq
-9012;argagnon
-9013;montreuil-bellay centre
-9014;baigts-de-béarn
-9015;achères
-9016;labatut
-9017;villefranche-d’allier
-9018;sames—guiches
 9019;st-denis
-9020;st-denis-voyageurs
-9021;urcuit
-9022;castagnède
-9023;escos
-9024;arrive
-9025;rivehaute
-9026;nabas
-9027;la roche gendarmerie
-9028;viodos
-9029;la croix-du-prince
-9030;pont-de-rupt
-9031;st-agnant
-9032;st-denis-d’oléron
-9033;dinard office de tourisme
 9034;albigny—neuville
 9035;chanas
-9036;les chères
-9037;orly
-9038;aéroport-d’orly-val
-9039;heuilley-cotton
-9040;le vaudioux
-9041;philippsbourg
-9042;bouzonville
-9043;occey
-9044;violot
-9045;les verrières frontière
-9046;ébersviller
-9047;kédange
-9048;st-varent
-9049;kuntzig
-9050;bassanese
-9051;grozon
-9052;passenans
-9053;montain
-9054;aulon
-9055;st-martin-de-la-cluze
-9056;st-michel-les-portes
-9057;carcassonne gare routière
-9058;gare zone 2-3
-9059;le percy
-9060;rohrbach-lès-bitche
-9061;st-maurice-en-trièves
-9062;enchenberg
-9063;piène-basse
-9064;st-julien-en-beauchêne
-9065;la faurie—montbrand
-9066;labastide-d’anjou hôtel
-9067;guzet-neige
-9068;barenton
-9069;jolimetz-herbigniès
-9070;ruesnes
-9071;ceppe
-9072;gare allemande
-9073;gare francaise
-9074;calvi
-9075;calvi
-9076;soum—pic-du-jer
-9077;gare italienne
-9078;narrosse
-9079;ally
-9080;hinx-sur-adour
-9081;gamarde-les-bains
-9082;origine-pass
-9083;yzemgremer
-9084;montfort-en-chalosse
-9085;mugron
-9086;toulouzette
-9087;montaut
-9088;augreilh
-9089;mauco—benquet
-9090;st-sever
-9091;avoise
-9092;venaco
-9093;clefs centre
-9094;grand’combe-châteleu
-9095;belvédère
-9096;val-d’europe
-9097;romilly-sur-seine rue pierre sémard
-9098;tulle
-9099;besse-sur-braye
-9100;dompierre-sur-mer
-9101;courtalain
 9102;vitrolles aéroport marseille-provence ter
-9103;st-agil
-9104;chatelay
-9105;deutschland db dr 80
-9106;villers-le-lac
-9107;magnières
-9108;aiglun
-9109;drugeac—drignac
 9110;ste-maxime
-9111;coulon
-9112;trugny
-9113;augerans
-9114;belmont
-9115;fontaines
-9116;cramans
-9117;germigney
-9118;boujailles
-9119;benet centre
-9120;prégnin
-9121;les longevilles—rochejean
-9122;ferney lycée
-9123;sézanne
-9124;sézanne église
-9125;vers-en-montagne
-9126;creutzwald
-9127;la brée
-9128;ste-fontaine
-9129;aubenas pont
-9130;farébersviller
-9131;farschviller
-9132;friedrichshafen
-9133;beaucroissant
-9134;brignoles
-9135;la cotinière
-9136;st-jean-de-moirans
-9137;corbeil-essonnes
-9138;carte-orange
-9139;domène
-9140;jussy
-9141;lespouey—laslades
-9142;ampèrevielle
-9143;le cheylas—la buissière
-9144;st-sébastien-sur-loire
-9145;villefranche-de-rouergue farrou
-9146;corte
-9147;lourquen
-9148;lugny
-9149;roissy-aéroport-cdg 2
-9150;laroche-st-cydroine
-9151;brienon
-9152;gallardon pont
-9153;nanterre
-9154;aéroport-charles-de-gaulle-1
-9155;cuiseaux
-9156;issy-les-moulineaux
-9157;issy-val-de-seine
-9158;la milesse—la bazoge
-9159;labarre
-9160;suresnes-longchamps
-9161;douvot
-9162;ougney-douvot
-9163;hyèvre-paroisse
-9164;echillais
-9165;st-lunaire
-9166;achères-grand-cormier
-9167;longemaison
-9168;st-eloy-les-mines lycée
-9169;navilly
-9170;st-bonnet-en-bresse
-9171;trappes
-9172;trappes-voyageurs
-9173;st-germain-du-bois—devrouze
-9174;simard
-9175;agglomération-de-st-quentin
-9176;ste-croix
-9177;pithiviers
-9178;puteaux
-9179;st-gaultier
-9180;balme—araches
-9181;aubenas centre
 9182;domancy
-9183;le châtelard—gietroz
-9184;polminhac
-9185;liesse-gizy
-9186;contremarque
 9187;aéroport paris orly
-9188;st-andré-de-najac
-9189;la fouillade
-9190;île-rousse
-9191;sanvensa
-9192;pentrez plage
-9193;gouttières
-9194;cahors
-9195;margaux bourg
-9196;alles-sur-dordogne
-9197;le porage
-9198;parc-st-cloud
-9199;la jumellière
-9200;la plaine—stade de france
-9201;trémentines
-9202;ancy-le-franc
-9203;st-georges-sur-loire
-9204;lezinnes
-9205;ingrandes
-9206;tanlay
-9207;aisy
-9208;montrelais
-9209;bettembourg frontière
-9210;port-st-père
-9211;aubecourt
-9212;chaumont-sur-tharonne
-9213;dole la bédugue
-9214;prigonrieux—la force
-9215;creysse—mouleydier
-9216;st-capraise-de-lalinde
-9217;st-dizier-leyrenne
-9218;longwy route de metz
-9219;sauvebœuf
-9220;bloye
-9221;mazamet
-9222;morhange
-9223;marcellaz—hauteville
-9224;feignies
-9225;evires
-9226;thyez—le-nanty
-9227;le croezou
-9228;lamativie
-9229;plogonnec
-9230;ploëven
-9231;artres
-9232;jeumont frontière
-9233;st-brice (orne)
-9234;luitre
-9235;salins
-9236;orgerus—béhoust
-9237;tacoignières-richebourg
-9238;jaleyrac—sourniac
-9239;houdan
-9240;marchezais-broué
 9241;ermont
-9242;largnac
-9243;petit-jouy—les loges
-9244;jouy-en-josas
-9245;laguépie église
-9246;arpajon-sur-cère
-9247;vauboyen
-9248;bièvres
-9249;igny
-9250;la tour-de-faure
-9251;st-jal
-9252;plaisir—les clayes
-9253;chilly-mazarin
-9254;vire-sur-lot port
-9255;st-jean-froidmentel
-9256;gravigny-balizy
-9257;aunay-tréon
-9258;touille
-9259;st-quentin-en-yvelines
-9260;villiers—neauphles—pontchartrain
-9261;st-trojan-les-bains
-9262;montfort-l’amaury—méré
-9263;balaruc-les-bains
-9264;punerot
 9265;honfleur
-9266;ruppes
-9267;le grand-village
 9268;oloron-ste-marie impôts
-9269;nice cfp voyageurs
 9270;oloron-ste-marie station
-9271;gétigné centre
-9272;bocognano
-9273;perros-guirec
 9274;la grande-motte
-9275;rezé—pont-rousseau pirmil
-9276;st-usuge
-9277;sarreguemines est
-9278;welferding rue de france
-9279;le bas-de-collonges
-9280;francardo
-9281;st-cergues
-9282;apach frontière
-9283;lully
-9284;mezzana
-9285;vongy
-9286;amphion-les-bains
-9287;wissembourg frontière
-9288;montcaret
-9289;ludon église
-9290;rehon poste
-9291;anglefort
-9292;la plaine
-9293;champ-du-chêne
-9294;lavaur
-9295;st-michel
 9296;chénérailles
-9297;meudon
-9298;bellevue
 9299;gap
-9300;st-méen-le-grand
-9301;lignerolles
-9302;sèvres
-9303;sèvres-rive-gauche
-9304;teillet-argenty
-9305;versailles-rive-gauche
-9306;porchefontaine
-9307;reterre
-9308;chaville
-9309;chaville-vélizy
-9310;chaville-rive-gauche
-9311;viroflay
-9312;viroflay-rive-gauche
-9313;st-cyr
-9314;trappes
-9315;beyredes
-9316;la verrière
-9317;pont-de-camous
-9318;merdrignac
-9319;coignières
-9320;st-briac
-9321;les essarts-le-roi
-9322;le perray
-9323;issy-val-de-seine
-9324;provins
 9325;gazeran
-9326;saleich
 9327;val-d’isère
-9328;mauvezin-de-prat
-9329;beynes
-9330;fontenay-le-fleury
-9331;villepreux-les-clayes
-9332;plaisir—grignon
-9333;garancières-la-queue
-9334;prat bonrepaux
-9335;sentaraille
-9336;si-val-de-seine
-9337;torfou
-9338;la noué beauvais
-9339;les moutiers-en-retz
-9340;la bernerie-en-retz
-9341;serrigny
-9342;montigny-lès-vesoul
-9343;chariez
-9344;caudos
-9345;solférino
-9346;lunéville
-9347;rémilly place du 11 novembre
-9348;vatimont mairie
-9349;torcieu
-9350;ucciani
-9351;rossillon
-9352;velosnes abri
-9353;neuilly-porte maillot
-9354;villecloye
-9355;airans
-9356;longchamp
-9357;cappelle-huquinville
-9358;la fenière
-9359;ucel
-9360;neuville-aux-bois
-9361;sergy
-9362;flies
-9363;mavault
-9364;cessy
-9365;arbère
-9366;le gault-soigny mairie
-9367;blandain frontière
-9368;godewaersvelde-frontière
 9369;biscarrosse
-9370;tourcoing frontière
-9371;zuydcoote
-9372;zuydcoote
-9373;sanatorium-de-zuydcoote
-9374;neuville-universite
-9375;neuvy
-9376;soussans
-9377;nogent-sur-loir
-9378;nogent-sur-loir centre
-9379;port-st-père centre
-9380;aéroport-d’orly
-9381;st-julien-l’ars
-9382;musée-sèvres
-9383;vanves-malakoff
-9384;clamart
-9385;piau-engaly—aragnouet
-9386;goux
-9387;invalides
-9388;pont-de-l’alma
-9389;champ de mars - tour eiffel bir-hakeim
-9390;javel
-9391;issy-les-moulineaux
-9392;les bories
-9393;meudon-val-fleury
-9394;mirande
-9395;crancey
-9396;pont-sur-seine
-9397;mercus-garrabet centre
-9398;magné
-9399;pontivy
-9400;villefranche-de-lauragais gendarmerie
-9401;st-christophe-du-ligneron
-9402;st-maurice
-9403;douarnenez
-9404;rang
-9405;pompierre
-9406;billère
-9407;parempuyre église
-9408;boos
-9409;candresse
-9410;boulogne-sur-mer maritime
-9411;carresse
-9412;castetis
-9413;decazeville lycée polyvalent
-9414;modane frontière
-9415;cauneille
-9416;colombier
-9417;charritte
-9418;saulx
-9419;denguin
-9420;genévreuille
-9421;espiute
-9422;gestas
-9423;hastingues
-9424;liposthey
-9425;la ferté-alais
-9426;mios
-9427;mont
-9428;nousse
-9429;parentis
-9430;langres oertli
-9431;sanguinet
-9432;st-gladie
-9433;tabaille-usquain
-9434;pierroton
-9435;dortan—lavancia
-9436;jeurre—vaux
-9437;la noué
-9438;vaux-les-st-claude
-9439;chassal
-9440;lavans—st-lupicin
-9441;arcomie
-9442;brindisi-patras
-9443;annœullin
-9444;gondecourt
-9445;monte-carlo country club
 9446;la défense
-9447;villennes-sur-seine
-9448;vernouillet-verneuil
-9449;les clairières-de-verneuil
-9450;les mureaux
-9451;aubergenville-elisabethville
-9452;epône—mézières
-9453;badaroux
-9454;larzalier
-9455;daufage—le-goulet
-9456;asr-thésée
-9457;aéroport-charles-de-gaulle-2-s
-9458;hermerswiller
-9459;kutzenhausen
-9460;oberkutzenhausen
-9461;merkwiller-pechelbronn
-9462;cérences
-9463;compertrix
-9464;orly ville
-9465;coolus
-9466;le grand-bourg
-9467;pontoise
-9468;la ferté-hauterive
-9469;vertheuil
-9470;bourg-lastic—messeix
-9471;créchy
-9472;villers-sur-mer centre
-9473;valdoie
-9474;melun robert schuman
-9475;pyramide-de-brunoy
-9476;melun andré malraux
-9477;fénétrange
-9478;fénétrange mairie
-9479;artiguillon
-9480;st-julien—montricher
-9481;trompeloup
-9482;la praz
-9483;auterrive
-9484;banos
-9485;bellocq
-9486;la peyratte
-9487;léaz
-9488;ecorans
-9489;vanchy
 9490;lérouville
-9491;joncels
-9492;rosendaël
-9493;leffrinckoucke
-9494;bray-dunes
-9495;bray-dunes-frontière
-9496;châtel-guyon
-9497;marignac
-9498;versailles-rive-droite
-9499;luzech
-9500;montreuil
-9501;viroflay-rive-droite
-9502;massy-verrières
-9503;puy-l’évêque
-9504;la défense sncf
-9505;stade-de-france—st-denis
-9506;la garenne-colombes
-9507;les vallées
-9508;naussac
-9509;nanterre université
-9510;st-georges
-9511;nanterre préfecture
-9512;houilles-carrières-sur-seine
-9513;sartrouville
-9514;segala
-9515;furiani
-9516;maisons-laffitte
-9517;herrin
-9518;pexiora
-9519;poissy
-9520;benevent-l’abbaye
-9521;barisey-au-plain—allamps
-9522;calais auto/train
-9523;lancieux
-9524;palinges
-9525;piène
-9526;mourioux—vieilleville
-9527;ponte-nuovo
-9528;bussy-st-georges
-9529;belleroche
-9530;st-yan
-9531;gretz-armainvilliers
-9532;bard-le-régulier
-9533;sézanne
-9534;st-jean-de-la-porte
-9535;épertully
-9536;gros-noyer—st-prix
-9537;st-leu-la-fôret
-9538;aéroport-charles-de-gaulle-2-rer
-9539;vaucelles
-9540;taverny
-9541;bessancourt
-9542;frépillon
-9543;méry-sur-oise
-9544;mériel
-9545;grand-pont—preuilly
-9546;st-étienne—menet
-9547;landres
-9548;orbé
-9549;nointel—mours
-9550;couhé—verac
-9551;paris-la chapelle
-9552;st-martin-de-queyrières
-9553;herblay
-9554;paris salon vip
-9555;conflans-ste-honorine
-9556;neuville-de-poitou
 9557;cergy
-9558;cergy-prefecture
-9559;villiers
-9560;bécon-les-bruyères
-9561;courbevoie
-9562;la défense
-9563;garches—marnes-la-coquette
-9564;vaucresson
-9565;chaville-rive-droite
-9566;sèvres-ville-d’avray
-9567;paraire
-9568;st-cloud
-9569;monteils
-9570;le val-d’or
-9571;suresnes-mont-valérien
-9572;puteaux
-9573;viazac
-9574;la celle-st-cloud
-9575;bougival
-9576;louveciennes
-9577;marly-le-roi
 9578;st-cirq-lapopie
-9579;l’étang-la-ville
-9580;urt centre
-9581;couilly—st-germain—quincy
-9582;st-nom-la-bretêche-forêt marly
-9583;villiers-montbarbin
-9584;cergy-st-christophe
-9585;crécy-la-chapelle
-9586;les champs-forts
-9587;auxon
-9588;st-martin-de-bouillac
-9589;la boissière
-9590;douelle
-9591;le ponthou
-9592;corlée
-9593;allennes-les-marais
-9594;heuilley-le-grand
-9595;villedieu—chanliau
-9596;chassigny
-9597;dommarien
-9598;taule
-9599;st-gilles (saône-et-loire)
-9600;maison-dieu
-9601;coatloc’h
-9602;st-andré-en-terre-plaine
-9603;noidans-le-ferroux
-9604;ventimiglia
-9605;ostheim
-9606;bennwihr
-9607;mittersheim
-9608;mittersheim l’escale
-9609;toulon-sur-allier
-9610;la loye
-9611;aspach-le-haut le pont
-9612;aspach-le-haut
-9613;santans
-9614;savigny—cercy
-9615;st-jean-de-muzols
-9616;deuil-montmagny
-9617;groslay
-9618;sarcelles—st-brice
-9619;wannehain frontière
-9620;ecouen—ezanville
-9621;st-leu-d’esserent
-9622;précy-sur-oise
-9623;lacanau
-9624;domont
-9625;boran-sur-oise
-9626;bruyères-sur-oise
-9627;romilly-sur-seine gornet boivin
-9628;bouffémont-moisselles
-9629;maffliers
-9630;montsoult-maffliers
-9631;presles—courcelles
-9632;lacanau ville
-9633;malbosc
-9634;champagne-sur-oise
-9635;l’isle-adam—parmain
-9636;les côteaux
-9637;valmondois
-9638;auvers-sur-oise
-9639;belloy—st-martin
-9640;pont-tranchefetu arrêt autocar
-9641;viarmes
-9642;luzarches
-9643;ermont-halte
-9644;ringendorf
-9645;éragny—neuville
-9646;st-ouen-l’aumône église
-9647;chanteloup-les-vignes
-9648;maurecourt
-9649;valence gare routière
-9650;andrésy
-9651;juziers
-9652;gargenville
-9653;issou-porcheville
-9654;flaujac
-9655;limay
-9656;mantes-station
-9657;la chapelle-de-mareuil
-9658;ménerville
-9659;st-andré-les-vergers centre commercial
-9660;anglars-nozac
-9661;gilles-guainville
-9662;mareil-sur-mauldre
-9663;maule
-9664;st-clair
-9665;nézel—aulnay
-9666;st-dizier gare routière
-9667;thédirac—peyrilles
-9668;val-d’argenteuil
-9669;st-dizier hôtel de ville
-9670;chailly—boissy-le-châtel
-9671;triel-sur-seine
-9672;st-denis-catus
-9673;vaux-sur-seine
 9674;gausbach
-9675;thun-le-paradis
-9676;chauffry
-9677;meulan-hardricourt
-9678;argenteuil
-9679;st-siméon
-9680;auzits—aussibals
-9681;cormeilles-en-parisis
-9682;st-rémy-la-vanne
-9683;la frette—montigny
-9684;jouy-sur-morin—le marais
-9685;jacques-henri lartigue
-9686;la ferté-gaucher
-9687;montry—condé
-9688;nuces
-9689;changis—st-jean
-9690;saulieu place
-9691;plémet
-9692;nanteuil-saâcy
-9693;ponte-leccia
-9694;nogent-l’artaud—charly
-9695;chézy-sur-marne
-9696;hanvec
-9697;isles—armentières—congis
-9698;montlaur-en-diois
-9699;lizy-sur-ourcq
-9700;peronnas
-9701;crouy-sur-ourcq
-9702;cc-mail-21/6-période-3
-9703;douarnenez ancienne gare
-9704;verrières-de-joux
-9705;guengat
-9706;mareuil-sur-ourcq
-9707;le rody
-9708;bastia
-9709;cergy-le-haut
-9710;anom-63366
-9711;ugny-sur-meuse
-9712;les girarmes
-9713;magenta
-9714;pont-de-livron
-9715;sarraltroff
-9716;pleaux
-9717;tattone
-9718;tavera
-9719;noyal-sur-brutz
-9720;montmirail
-9721;lunéville cité scolaire
 9722;montélimar gare routière
-9723;dompierre-du-chemin
-9724;châtillon-en-vendelais
-9725;wolfgantzen
-9726;neuf-brisach
-9727;balaze
-9728;lac-de-malaguet
-9729;appenwihr
-9730;morhange pointcarré
-9731;enghien-les-bains
-9732;champ-de-courses-d’enghien
-9733;ermont—eaubonne
-9734;cernay rer
-9735;le bourget
-9736;franconville—le plessis-bouchard
-9737;montigny-beauchamp
-9738;pierrelaye
-9739;st-ouen-l’aumône
-9740;épluches
-9741;la fontaine-st-martin centre
-9742;pont-petit
-9743;chaponval
-9744;st-gratien
-9745;sannois
-9746;garges—sarcelles
-9747;villiers-le-bel—gonesse—arnouville
-9748;les noues
-9749;goussainville
-9750;louvres
-9751;survilliers—fosses
-9752;la borne-blanche
-9753;colombes
-9754;le stade
-9755;pont-cardinet
-9756;clichy—levallois
-9757;asnières-sur-seine
-9758;osny
-9759;boissy-l’aillerie
-9760;montgeroult—courcelles
-9761;us
-9762;monferran
-9763;santeuil—le perchay
-9764;lépange
-9765;chars
-9766;concoules—ponteils
-9767;lavilletertre
-9768;chaumont-en-vexin
-9769;trie-château
-9770;alba pont des sceautres
-9771;champbenoist—poigny
-9772;ozoir-la-ferrière
-9773;bouconvillers
-9774;roissy-en-brie
-9775;nucourt
-9776;lalouvesc
-9777;emerainville—pontault-combault
-9778;magny-en-vexin
-9779;st-cernin
-9780;casamozza
-9781;villepatour-presles
-9782;ozouer-le-voulgis
-9783;st-crépin
-9784;verneuil-l’étang
-9785;mormant
-9786;nangis
-9787;meaux
-9788;chelles—gournay
-9789;ste-colombe—septveilles
-9790;sauveterre-de-béarn centre
 9791;nemours-st-pierre
-9792;tournan
-9793;bagneaux-sur-loing
-9794;marles-en-brie
-9795;dordives
-9796;mortcerf
-9797;guérard—la celle-sur-morin
-9798;ferrières—fontenay
-9799;faremoutiers—pommeuse
-9800;vaires-torcy
-9801;boigneville
-9802;coulommiers
-9803;malesherbes
-9804;lagny—thorigny
-9805;esbly
-9806;st-georges-d’oléron
-9807;gare de lyon-banlieue
-9808;gare etc allemande
-9809;paris bercy commercial
-9810;gare zone 4
-9811;gare etc francaise
-9812;paris-charolais
-9813;gare etc italienne
-9814;lapeyrouse (ain)
-9815;lempdes
-9816;mirabel-et-blacons
-9817;défense
-9818;brioude lycée lafayette
-9819;meudon-sur-seine
-9820;st-germain-sur-meuse
-9821;avessac
-9822;villaines
-9823;seychalles—moissat
-9824;seugy
-9825;compans
-9826;la monnerie—st rémy
-9827;thieux-nantouillet
-9828;irlande-60
-9829;les prés-roseaux
-9830;barbentane—rognonas
-9831;graveson—maillane
-9832;st-gabriel
-9833;les grésillons
-9834;pont-l’évêque-sur-oise
-9835;la ferrière
-9836;villeneuve-les-avignon
-9837;rochemaure centre
-9838;seigneur-dieu
-9839;omessa
-9840;boursay
-9841;pasilly
-9842;le mans gare autotrain
-9843;st-dizier base aérienne
-9844;péreire-levallois
-9845;villiers-sur-marne—le plessis-trévise
-9846;les yvris—noisy-le-grand
-9847;les coquetiers
-9848;avenue-foch
-9849;avenue-henri-martin
-9850;les pavillons-sous-bois
-9851;gargan
-9852;allée-de-la-tour-rendez-vous
-9853;l’abbaye
-9854;bois-colombes
-9855;freinville-sevran
-9856;ligny-st-flochel
-9857;algajola
-9858;boutique-fontenay
-9859;la seyne-sur-mer
-9860;la beuvrière
-9861;fontcouverte—pujols
-9862;loury église
-9863;nogent-sur-loir
-9864;luxembourg
-9865;belgodère
-9866;grenoble gare routière
-9867;biguglia
-9868;domfront
-9869;domfront
-9870;ceauce
-9871;bagnoles-de-l’orne
-9872;montigny-sur-loing
-9873;borgo
-9874;bourron-marlotte—grez
-9875;davia
-9876;frugières-le-pin
-9877;st-yorre
 9878;bagnoles-de-l’orne église
-9879;ourches-sur-meuse
-9880;mars-la-tour
-9881;st-martin—sail-les-bains
-9882;valenton
-9883;drancy
-9884;aulnay-sous-bois
-9885;esternay
-9886;sevran—livry
-9887;châtel-guyon
-9888;st-valéry-en-caux port
-9889;paris austerlitz rer c
-9890;vert-galant
-9891;musée-d’orsay
-9892;sevran—beaudottes
-9893;st-michel-notre-dame
-9894;boulevard massena
-9895;canquillac
-9896;ste-brigitte
-9897;st-trélody
-9898;villepinte rer
-9899;pontivy
-9900;le blanc-mesnil
-9901;la roche-de-rame
-9902;prareboul
-9903;parc-des-expositions
-9904;villeparisis
-9905;mitry—claye
-9906;st-martin-de-queyrières
-9907;prelles
 9908;dammartin—juilly—st-mard
-9909;chamandrin
 9910;le plessis-belleville
-9911;la bâtie-montsaléon
 9912;nort-sur-erdre
-9913;pont-de-chabestan
-9914;montrond
-9915;eyguians
-9916;houlgate centre
 9917;le teil
-9918;avignon sud
-9919;oisy-le-verger
-9920;coex centre
-9921;sancourt
-9922;mont-coupot
-9923;verniolle
-9924;boulogne-sur-mer maritime
-9925;pantin
-9926;sarras
-9927;noisy-le-sec
 9928;les masseries
-9929;bondy
-9930;le raincy—villemomble—montfermeil
 9931;st-mammès
-9932;gagny
-9933;livry-sur-seine
-9934;le chénay-gagny
-9935;chartrettes
-9936;fontaine-le-port
 9937;évry
-9938;héricy
-9939;rosny—bois-perrier
-9940;vulaines-sur-seine-samoreau
-9941;champagne-sur-seine
-9942;rosny-sous-bois
-9943;vernou-sur-seine
-9944;val-de-fontenay
-9945;la grande-paroisse
-9946;le teil ter
-9947;nogent—le perreux
-9948;vosves
-9949;mont-st-éloi
-9950;boissise-le-roi
-9951;les boullereaux—champigny
-9952;ponthierry-pringy
-9953;st-fargeau
-9954;bibliothèque françois mitterrand
-9955;cézy
-9956;bouligny centre
-9957;vitry-la-ville
-9958;brienon
-9959;st-florentin-ville
-9960;cheny
-9961;bonnard-bassou
-9962;cérences
-9963;st-jean-d’heurs
-9964;paris-s.urb.m.
-9965;revel
-9966;sanguinet
-9967;st-gervais-sous-meymont
-9968;la norville—st-germain-lès-arpajon
-9969;arpajon
-9971;égly
 9972;st-georges-d’aurac bourg
-9973;breuillet—bruyères-le-châtel
-9974;rougeac—chavaniac
-9975;breuillet-village
-9976;lissac
-9977;recet ari pv 11
-9978;st-chéron
-9979;st-vidal
-9980;sermaise
-9981;st-denis
-9982;fontannes
-9983;pussay
-9984;pussay route de monnerville
-9985;club-olympique
-9986;épinay—villetaneuse
-9987;club-med-cocody
-9988;épinay-sur-seine
-9989;pierrefitte-stains
-9990;sant’ambroggio
-9991;la barre—ormesson
-9992;tepina
-9993;gennevilliers
-9994;lupino
 9995;deauville
-9996;rivoli
-9997;orly aérogares
-9998;l’arinella
-9999;st-ouen
-10000;pont-de-rungis-aéroport-d’orly
-10001;st-ouen garibaldi
-10002;montesoro
-10003;les saules
-10004;la courneuve—aubervilliers
-10005;la rocade
-10006;rungis-la-fraternelle
-10007;la beaume
-10008;la fourchette
-10009;antony
-10010;chemin-d’antony
-10011;st-pierre-d’argenton
-10012;aspremont
-10013;montmaur
-10014;la roche-des-arnauds
-10015;la freissinouse
-10016;la bâtie-neuve—le-laus
-10017;tronget
-10018;pussay place du carrouge
-10019;la vancelle
-10020;prunières
-10021;pont-hamon
-10022;savines
-10023;les crots
-10024;châteauroux-les-alpes
-10025;st-clément
-10026;chaumeil
-10027;lamothe-fénelon
-10028;mertzwiller église
-10029;le locle
-10030;lyon st-clair
-10031;boulevard victor - pont du garigliano
-10032;orlyval
-10033;le bras de fer
-10034;moulin-galant
-10035;mennecy
-10036;les flambans
-10037;ballancourt
-10038;l’hôpital-sur-rhins
-10039;le canton
-10040;pierrefitte-sur-loire
-10041;pins-justaret cepette
-10042;ainay-le-vieil
-10043;maisse
-10044;buno—gironville
-10045;aéroport paris orly ouest
-10046;essonnes-robinson
-10047;aéroport paris orly sud
-10048;pithiviers mail
-10049;villabé
-10050;le plessis-chenet
-10051;le coudray-montceaux
-10052;villeneuve-triage
-10053;villeneuve-st-georges
-10054;villeneuve—prairie
-10055;blonville centre
-10056;montgeron-crosne
 10057;st-sébastien-sur-loire pas enchantés
-10058;yerres
-10059;brunoy
-10060;boussy-st-antoine
-10061;gare zone 5
-10062;combs-la-ville—quincy
-10063;lieusaint—moissy
-10064;cesson
-10065;gare zone 6
-10066;le mée
-10067;brouvelieures forges
-10068;canisy
-10069;savigny-le-temple-nandy
-10070;bruyères rue cameroun
 10071;bois-le-roi
-10072;thomery
 10073;st-hilaire-de-chaléons
-10074;chef-du-pont—ste-mère
-10075;montigny-sur-meuse
-10076;airvault centre
-10077;valence place leclerc
-10078;st-didier-en-velay la seauve
-10079;castella
-10080;domfessel
-10081;st-michel-sur-charente
-10082;puberg
-10083;monnerville centre
-10084;guillerval montdésir
-10085;beauzac
-10086;imling
-10087;pithiviers
-10088;st-hilaire-de-chaléons centre
-10089;paris tolbiac
-10090;vendranges—st-priest
-10091;rombach-le-franc
-10092;paris tolbiac taa
-10093;lacourt
-10094;étréchy
-10095;soueix
-10096;chamarande
-10097;seix
-10098;st-marcel-lès-valence
-10099;lardy
-10100;oust
-10101;bouray
-10102;marolles-en-hurepoix
-10103;guzet-neige
-10104;st-michel-sur-orge
-10105;guzet roc blanc
-10106;ste-geneviève-des-bois
-10107;soultz-les-bains
-10108;épinay-sur-orge
-10109;odratzheim
-10110;savigny-sur-orge
-10111;athis-mons
-10112;scharrachbergheim
-10113;villeneuve-le-roi
-10114;kirchheim
-10115;choisy-le-roi
-10116;pont-de-quart
-10117;marlenheim
-10118;recoubeau
-10119;le kronthal
 10120;vitry-sur-seine
-10121;wangen
-10122;lumio
-10123;ivry-sur-seine
-10124;wasselonne
-10125;le regino
-10126;st-martin-d’étampes
-10127;romanswiller
-10128;les ifs
-10129;singrist
-10130;guer
-10131;novella
-10132;ploërmel
-10133;fornacina
-10134;palasca
-10135;josselin
-10136;pietralba
-10137;poggio-riventosa
-10138;san-gavino
-10139;soveria
-10140;vivario
-10141;st-martin-le-beau
-10142;ardentes
-10143;la châtre
-10144;marne-la-vallée—chessy
-10145;chilleurs-aux-bois
-10146;moulis—listrac carrefour d2/d5
-10147;pontgibaud ville
-10148;liverdy-en-brie
-10149;avis voiture tests
-10150;aller-retour
-10151;maisons-alfort—alfortville
-10152;le vert-de-maisons
-10153;vigneux-sur-seine
-10154;masbaraud-merignat
-10155;le merlerault
-10156;viry-châtillon
-10157;mœurs
-10158;ris-orangis
-10159;orangis-bois-de-l’épine
-10160;écouché
-10161;grand-bourg
-10162;évry
-10163;grigny centre
-10164;évry-courcouronnes
-10165;montmarault
-10166;le montet
-10167;friedrichshafen
-10168;morsains
-10169;sous-st-jean
-10170;grand-croix
-10171;couzon
-10172;lugagnac
-10173;artouste-fabrèges télécabine
-10174;tulle marquisat
-10175;caldaniccia
-10176;dourdan-la-forêt
-10177;calais armement naval
-10178;mezel—châteauredon
-10179;barrème
-10180;st-andré-les-alpes
-10181;carbuccia
-10182;thorame-haute
-10183;annot
-10184;entrevaux
-10185;puget-theniers
-10186;touët-sur-var
-10187;villars-sur-var
-10188;la vésubie—plan-du-var
-10189;boulainvilliers
-10190;st-martin-du-var
-10191;avenue du président kennedy-radio france
-10192;porte-de-clichy
-10193;gratuit
-10194;andancette
-10195;angerville salle des fêtes
-10196;st-vincent-de-cosse
-10197;chéry—lury
-10198;irmstett
-10199;courquetaine
-10200;montierchaume
-10201;laroquebrou centre
-10202;avolsheim
-10203;pibrac rn lengel
-10204;sisteron
-10205;neuillé-pont-pierre gendarmerie
-10206;wiencourt-l’équipée
-10207;yebles-guignes
-10208;curchy-dreslincourt
-10209;le parc-de-st-maur
-10210;jumelles
-10211;nieul-sur-l’autise
-10212;fontaine-lavaganne
-10213;grez-gaudechart
-10214;sames—guiches
-10215;moliens
-10216;montauban-de-bretagne ville
-10217;draguignan
-10218;hadancourt
 10219;hendaye-plage — les deux jumeaux
-10220;hendaye frontière
-10221;sérans
-10222;montcenis
-10223;guillerval centre
-10224;etivau
-10225;haussmann-st-lazare
-10226;montargis gare routière
-10227;les ardoines
-10228;tours grammont
-10229;st-révérend
-10230;roville—st-maurice
-10231;laplace
-10232;arcueil—cachan
-10233;bagneux
-10234;darnieulles—uxegney
-10235;bourg-la-reine
-10236;beost
-10237;sceaux
-10238;fontenay-aux-roses
-10239;robinson
-10240;aizenay
-10241;parc-de-sceaux
-10242;la croix-de-berny
-10243;lusse
-10244;dax place st-pierre
-10245;fontaine-michalon
-10246;les baconnets
-10247;massy-verrières rer
 10248;cabourg
-10249;paris austerlitz automates
-10250;massy—palaiseau rer
-10251;palaiseau
-10252;palaiseau—villebon
-10253;lozère
-10254;le guichet
-10255;orsay ville
-10256;bures-sur-yvettes
-10257;la hacquinière
-10258;gif-sur-yvette
-10259;courcelle-sur-yvette
-10260;st-rémy-les-chevreuses
-10261;paris section urbaine
-10262;surbourg
-10263;colomars
-10264;mazères-sur-salat centre
-10265;warluis
-10266;toulouse fabienne verdier
-10267;toulouse jean jaurès
-10268;blangy—glisy
-10269;avis
-10270;long—le-catelet
-10271;fontaine-sur-somme
-10272;suisse schweiz svizzera 85
-10273;braches
-10274;bouillancourt
-10275;domfront la compassion
-10276;les pégaux
-10277;frébécourt
-10278;montbras
-10279;port-villez
-10280;choloy
-10281;brimborion
-10282;la boisse
-10283;domfront centre
-10284;mont-sur-meurthe village
-10285;vizzavona
-10286;poussay
-10287;st-julien-sur-cher
-10288;le bellay-en-vexin
-10289;lierville
-10290;salers les quatre roues
-10291;vincennes
-10292;fontenay-sous-bois
-10293;nogent-sur-marne
-10294;joinville-le-pont
-10295;créteil
-10296;st-maur-des-fosses
-10297;satolas
-10298;champigny
-10299;la varenne-chennevières
-10300;sucy
-10301;boissy-st-léger-ratp
-10302;val-de-fontenay ratp
-10303;neuilly-plaisance
-10304;bry-sur-marne-rer
-10305;noisy-le-grand—mont-d’est
-10306;noisy—champs
-10307;fontenelle-en-brie
-10308;noisiel
-10309;beinheim
-10310;lognes
-10311;torcy-ratp
-10312;paris gare de lyon rer
-10313;auber-rer-a
-10314;châtelet-les-halles
-10315;luxembourg
-10316;port-royal rer b
-10317;denfert-rochereau
-10318;cité universitaire-rer
-10319;gentilly
-10320;otterswiller
-10321;marmoutier
-10322;agglomération-de-cergy-pontoise
-10323;grans
-10324;mietesheim
-10325;archamps
 10326;la seyne—six-fours
-10327;belley
-10328;chablis
-10329;égletons
-10330;falaise
-10331;grasse
-10332;lançon
-10333;les ulis
-10334;cordes-vindrac centre
-10335;peyrouton
-10336;digne-les-bains cfp voyageurs
-10337;domfront (oise)
-10338;maurepas
-10339;orgeval
-10340;behereharta
 10341;ouistreham
-10342;boissonnade
-10343;omaha-beach
-10344;andilly
-10345;champdeniers centre
-10346;saclay
-10347;st-cyprien
-10348;gérardmer
-10349;st-nectaire
-10350;sénard
-10351;hennecourt
-10352;sophia-antipolis
-10353;eyheralde
-10354;st-étienne-de-baigorry
-10355;lahonce
-10356;aéroport-charles-de-gaulle
-10357;dieppe terminal
-10358;barenton-cel
-10359;ste-colombe-les-vienne
-10360;barenton-sur-serre
-10361;bosmoreau-les-mines
-10362;st-romain-en-gier
-10363;petit-appeville
-10364;anneville-sur-scie
-10365;moulineaux
-10366;maizières-sur-amance
-10367;balesmes-sur-marne
-10368;chandieu—toussieu
-10369;amagne-ville
-10370;fontenay-le-comte gare routière
-10371;coulanges
-10372;charles-de-gaulle-étoile
-10373;la grande arche de la défense
-10374;nanterre préfecture rer
-10375;nanterre université rer
-10376;nanterre ville rer
-10377;rueil-malmaison-ratp
-10378;chatou-croissy-ratp
-10379;le vésinet centre
-10380;le vésinet-le pecq
-10381;pont-de-peyrelevade
-10382;st-germain-en-laye
-10383;nation
-10384;st-rémy (aveyron)
-10385;la cavalerie poste
-10386;district-mantes
-10387;l’hospitalet
-10388;le caylar
-10389;achicourt
-10390;alixan—châteauneuf-sur-isère
-10391;ponteau—st-pierre
-10392;arudy
-10393;izeste
-10394;bielle
-10395;pont-de-béon
-10396;laruns
-10397;guillaucourt
 10398;ogeu-les-bains
-10399;achères-ville
-10400;achy
-10401;briey
-10402;cerizay centre
-10403;marne-la-vallée—chessy ratp
-10404;bussy-ratp
-10405;rion-des-landes
-10406;laluque
-10407;buglose
-10408;limonest
-10409;grainville-ymauville
-10410;jussac
 10411;jacques-monod-la-demi-lieue
-10412;st-laurent-d’oingt
-10413;st-just-d’avray
-10414;grandris—allières
-10415;joiselle
-10416;claveisolles
-10417;la meilleraie
-10418;sigournais
-10419;irigny
-10420;souvigny
-10421;mauléon st-aubin
-10422;montarlot
-10423;hippodrome-de-la-côte-d’azur
-10424;juvisy
-10425;saumur ville
-10426;libre
-10427;noyant—méon
-10428;antully
-10429;tours lycée grandmont
-10430;cuon
-10431;forbach frontière
-10432;piène-basse
-10433;hanweiler grenze
-10434;trilport
-10435;piène-basse frontière
-10436;les bons-enfants
-10437;montfort
-10438;l’escale
-10439;rodange frontière
-10440;mison
-10441;barchetta
-10442;peipin
-10443;abense-de-bas
-10444;lurs
-10445;le chazal
-10446;laramière
-10447;abitain
-10448;oëx
-10449;ajaccio
 10450;toulouse roseraie
-10451;ablon
-10452;champtercier
-10453;les milons
-10454;autevielle
-10455;les sieyes
 10456;bologna centrale
 10457;bologna corticella
 10459;vicenza
@@ -8591,8 +6416,6 @@
 10462;novara
 10463;vercelli
 10464;innsbruck hbf
-10465;figueras (figueres)
-10466;autun st-jean
 10467;frontenaud mairie
 10468;st-amour abri ptt
 10469;nanc-lès-st-amour
@@ -8608,296 +6431,54 @@
 10479;les huichards
 10480;la chapelle-glain
 10481;figueres—vilafant
-10482;rzepin
 10483;poznań
-10484;kutno
 10485;wörgl
 10486;kufstein
 10487;jenbach
-10488;smolensk
 10489;minsk
-10490;brest-centralnyi
 10491;warszawa
 10492;warszawa-wschodnia
 10493;warszawa-centralna
-10494;moskva belorusskaya
 10495;saarbrücken
 10496;belfort—montbéliard tgv
 10497;la voulte cité
 10498;besançon-franche-comté tgv
-10499;montauban gare routière
 10500;louviers porte de l’eau
-10501;montauban prax
 10502;budapest-keleti
-10503;moskva kievskaia
 10504;vieille-brioude
 10505;toulouse argoulets
-10506;châtel-guyon office de tourisme
 10507;beauvais-sur-tescou
 10508;neuvy-sur-loire
 10509;myennes
-10510;poix-terron
 10511;ribeauvillé gare routière
 10512;st-nauphary
 10513;aubenas gare routière
-10514;aire de covoiturage 45
-10515;vieux thann zone industrielle
-10516;villefranche-de-lauragais cpam
-10518;pau bosquet halte
 10519;barbâtre
 10520;la guérinière
-10521;les cabannes centre
 10523;villach hbf
 10524;villach westbahnhof
-10525;zaragoza delicias
-10526;cloyes centre
-10527;st-florent-sur-cher bus
 10528;uzel aire de covoiturage (berlouze)
 10529;uzel centre
-10530;mont meurthe le mont
-10531;la motte
-10532;malemort-sur-corrèze
-10533;niederbronn
-10534;neufchâteau
-10535;montastruc
-10536;pons
-10537;roville aux chênes
-10538;romorantin
-10539;remiremont
-10540;reignac
-10541;saulxures
-10542;saint-mihiel
-10543;toul
 10544;aschaffenburg
-10545;decize lycée
-10546;la bresse claudel
-10547;imphy square lamartine
-10548;imphy le grand vernay
-10549;hôpital kerio
 10550;le bosquet
-10551;laroquebrou
-10552;lauterbourg
 10553;la frayère
-10554;labruguière
-10555;la bresse honeck
-10556;mauriac
-10557;mantes la jolie
-10558;lycée henri sellier
-10559;luzy ville
-10560;luzy premaude
-10561;lutterbach
-10562;lunery
-10563;louviers
-10564;loures
-10565;longwy car
-10566;longeville-sur-mogne mairie
-10567;lezoux
-10568;nevers mouesse anpe
-10569;mulhouse musées
-10570;morlaix
-10571;montauban
-10572;montastruc
-10573;montargis
-10574;mirande
-10575;meursault
-10576;meulan
-10577;metz car
-10578;pontgibaud
-10579;pierrefitte-sur-aire
-10580;peyruis péage
-10581;petit flez d985
-10582;perreuil
-10583;paulhaguet
 10584;beauvais gare routière
-10585;saint-berain
-10586;rougemont chanteloup
-10587;remise à jorelle
-10588;pregilbert
-10589;pougues les eaux mairie
-10590;sougy bif n81-d262
-10591;saint-pierre le moutier monument aux morts
-10592;saint-paul les durance cea iter
-10593;saint-ouen le port des bois
-10594;saint-ouen arrêt des cars
-10595;saint-lye
-10596;saint germain-lès-arlay
-10597;tannay place de l’église
-10598;villiers abribus
-10599;aix-en-provence gare routière
-10600;amiens gare routière
-10601;ax-les-thermes
 10602;aulnat aéroport
 10603;auch za de lamothe
-10604;anzeling
-10605;amiens
-10606;albias
-10607;aire-sur-l’adour
-10608;béziers
-10609;bénestroff
-10610;belfort—montbéliard
-10611;barisey-la-côte
-10612;castres
-10613;castelnaudary
-10614;carcassonne
-10615;brouvelieures
-10616;guémar poste
-10617;gosselming
-10618;gerbéviller lo
-10619;foix
-10620;distroff
-10621;keskastel
-10622;igney centre
-10623;gundershoffen
-10624;les cabannes
-10625;le deschaux
-10626;lavilledieu
-10627;lavelanet
-10628;moulet marcenat
-10629;metzervisse
 10630;poix-terron
-10631;planainseau
-10632;pamiers
-10633;saint-flour
-10634;rupt moselle
-10635;riom
-10636;réhon
-10637;réchicourt
-10638;reichshoffen
-10639;sisteron
-10640;sellières
-10641;schweighouse
-10642;schopperten
-10643;sarrewerden
-10644;sarre union
-10645;saléchan
-10646;saint-sauve
-10647;st ouen l’aumône liesse
-10648;saint-jean les longuyon
-10649;saint-jean de monts
-10650;triel
-10651;tournon
-10652;toulon
-10653;td tu stac chalon-sur-saône gare
-10654;td com ritmx 2 gare
-10655;td bur bouligny gare
-10656;tassenières
-10657;ussel
-10658;vougeot
-10659;villers le rond
-10660;villeneuve de berg
-10661;villefranche-sur-cher
-10662;villefranche lauragais
-10663;villefranche-de-rouergue
-10664;vernet d’ariège
-10665;saint-maurice
-10666;lérouville centre
-10667;mattaincourt
 10668;carhaix-plouguer
-10669;audun-le-roman
-10671;ancenis
-10672;barbezieux
-10673;châtillon-sur-seine
-10674;chantenay saint-imbert bourg
-10675;brioude
-10676;cornimont
-10677;conflans
-10678;fresse
-10679;dompaire
-10680;dommartin
-10681;la bresse
-10682;jonzac
-10683;issoire
-10684;igney—avricourt
 10685;hœnheim-tram
-10686;hielle
-10687;le thillot
-10688;aube
-10689;ambert
-10690;bourges
-10691;bort-les-orgues-ville
-10692;bois d’oingt
-10693;blesme
-10694;bessay
-10695;bayard route d’eurville
-10696;barbotan-les-termes
-10697;chatillon lycée
-10698;châteauneuf lamontgie
-10699;champagnole
-10700;bussang
-10701;brétigny
-10702;bretenoux—biars
 10703;daubech
-10704;daguerre
-10705;courçay la promenade
-10706;cormery
-10707;corgoloin
-10708;cloyes
-10709;clermont les cezeaux
-10710;gramat
-10711;gargenville
-10712;ermont—eaubonne
-10713;eloy
-10714;dunieres
-10715;juvisy
-10716;guiscriff
-10717;guéret
-10718;les 4 routes de saignes gare
-10719;le breuil-sur-couze
 10720;lanobre
-10721;mareil marly
-10722;mairie
-10723;noisy le roi
-10724;musées gare
-10725;montmorillon
-10726;porte haute
-10727;pontmort
-10728;pont-du-château
-10729;plaintel
-10730;nonant
-10731;st-florent-sur-cher
-10732;ste-christie
-10733;ruffec
 10734;rochefort-montagne
-10735;république
-10736;rennes
-10737;quintin
-10738;puy-guillaume
-10739;prayssac
-10740;porte jeune
-10741;saint-girons
-10742;saint-germain-en-laye
-10743;saint-germain-en-laye bel-air-fourqueux
-10744;touzac
-10745;tour nessel
 10746;thann centre
 10747;tauves
-10748;mulhouse zu-rhein
-10750;beard bourg
-10751;cercy la tour les brunettes
-10752;carrières-sous-poissy
-10753;carmaux
-10754;cuzy bureau de tabac
-10755;courçay
-10756;coulommiers
-10757;cosne-sur-loire sud
-10758;clamecy hôpital
-10759;druy parigny dardault
-10760;dornach gare
-10761;dennevy
-10762;decize ville
-10763;vernet d’ariège abri bus
-10764;vatimont
-10765;varilhes
-10766;metzervisse centre
 10767;mérignac-arlac
-10768;pussay château d’eau
-10769;villefranche-de-rouergue gr
 10771;regensburg
 10772;hildesheim
 10773;bielefeld
 10774;kaiserslautern
 10775;passau
-10776;oberhausen
 10777;nürnberg
 10778;limburg süd
 10779;essen
@@ -8906,25 +6487,10 @@
 10782;augsburg
 10783;esslingen (neckar)
 10784;lutherstadt wittenberg
-10785;la bresse le lispach
-10786;mulhouse gare routière
-10787;pontchâteau
-10788;porte puymorens station
-10789;uzel
-10790;cem centre d’exploitation et de maintenance
-10791;decize café bel aire
-10792;kassel
-10793;saint-leger des vignes rue des valettes
-10794;saint-germain-en-laye grande ceinture
-10795;toul gare routière
 10796;ulm
 10797;würzburg
-10798;limburg
-10799;aéroport-lyon-saint-exupéry
 10800;loudéac aire de covoiturage
-10801;furth im wald (gr)
 10802;alzey
-10803;kehl (gr)
 10804;babenhausen (hess)
 10805;bad nenndorf
 10806;bedburg (erft)
@@ -8953,8 +6519,6 @@
 10829;gruiten
 10830;weil am rhein-gartenstadt
 10831;weil am rhein-pfädlistraße
-10832;bad bentheim (gr)
-10833;weener (gr)
 10834;türkismühle
 10835;nidderau
 10836;herbertingen
@@ -8981,7 +6545,6 @@
 10858;rödermark-ober roden
 10859;zwickau zentrum
 10860;zwickau stadthalle
-10861;igel (gr)
 10862;quakenbrück
 10863;ludwigshafen (rhein) basf mitte
 10864;renningen
@@ -9045,14 +6608,12 @@
 10922;aichstetten
 10923;tuttlingen nord
 10924;ahnatal casselbreite
-10925;esens zob
 10926;ainring
 10927;münster-albachten
 10928;albbruck
 10929;albersdorf
 10930;albersweiler (pfalz)
 10931;albig
-10932;nürnberg-herrnhütte
 10933;albshausen
 10934;albstadt-ebingen
 10935;albstadt-laufen ort
@@ -9114,7 +6675,6 @@
 10991;anwanden
 10992;anzefahr
 10993;anzenkirchen
-10994;apach (fr)
 10995;nottuln-appelhülsen
 10996;ardey
 10997;arfurt (lahn)
@@ -9309,7 +6869,6 @@
 11186;hamburg billwerder-moorfleet
 11187;binau
 11188;bingen-gaulsheim
-11189;bingen (rhein) stadt
 11190;hagen-vorhalle
 11191;binolen
 11192;birkelbach
@@ -9544,7 +7103,6 @@
 11421;hamburg diebsteich
 11422;diedorf (schwab)
 11423;dietersheim
-11424;toender (gr)
 11425;dietzenbach mitte
 11426;dietzenbach bahnhof
 11427;diez ost
@@ -9730,7 +7288,6 @@
 11607;elz (limburg/lahn) süd
 11608;elzach
 11609;emmelshausen
-11610;emmerich (gr)
 11611;emmerke
 11612;empelde
 11613;emskirchen
@@ -9852,7 +7409,6 @@
 11729;fladungen
 11730;boppard-fleckertshöhe
 11731;flehingen
-11732;flensburg (gr)
 11733;flieden
 11734;flintbek
 11735;flintsbach
@@ -9860,7 +7416,6 @@
 11737;föhren
 11738;förbau
 11739;förtschendorf
-11740;forbach (fr)
 11741;forbach
 11742;forchheim (b karlsruhe)
 11743;fornsbach
@@ -10145,7 +7700,6 @@
 12022;hannover-bornum
 12023;hannover-leinhausen
 12024;hannover-linden/fischerhof
-12025;hanweiler (gr)
 12026;hannover flughafen
 12027;harblek
 12028;harburg (schwab)
@@ -10401,7 +7955,6 @@
 12278;kaiserslautern pfaffwerk
 12279;kaiserslautern west
 12280;kalchreuth
-12281;venlo (gr)
 12282;hürth-kalscheuren
 12283;langenhagen-kaltenweide
 12284;kalthof (kr iserlohn)
@@ -10451,7 +8004,6 @@
 12328;kirchdorf (deister)
 12329;kirchehrenbach
 12330;kirchentellinsfurt
-12331;kirchhalling
 12332;kirchheim (neckar)
 12333;kirchheim (teck)
 12334;kirchheim (teck) ötlingen
@@ -10627,7 +8179,6 @@
 12504;laupheim stadt
 12505;laurenburg (lahn)
 12506;lautenbach (baden)
-12507;lauterbourg (fr)
 12508;riedstadt-wolfskehlen
 12509;legden
 12510;legelshurst
@@ -10953,7 +8504,6 @@
 12830;nehren
 12831;dortmund-dorstfeld süd
 12832;nellmersbach
-12833;nemmenich
 12834;nendingen (b tuttlingen)
 12835;nennig
 12836;nersingen
@@ -11058,7 +8608,6 @@
 12935;nordendorf
 12936;nordenham
 12937;oberwerrn
-12938;nordhalben bf
 12939;nordhastedt
 12940;nordheim (württ)
 12941;nordwalde
@@ -11483,7 +9032,6 @@
 13360;schifferstadt süd
 13361;schiffweiler
 13362;schiltach mitte
-13363;cheb (gr)
 13364;schladern (sieg)
 13365;schliengen
 13366;schlierbach (schwalm-eder-kreis)
@@ -11635,7 +9183,6 @@
 13512;steinweiler
 13513;steinsfurt
 13514;steinwenden
-13515;steinwiesen bf
 13516;stelle
 13517;sterbfritz
 13518;sterzhausen
@@ -11806,7 +9353,6 @@
 13683;velden (b hersbruck)
 13684;vellmar-osterberg/ekz
 13685;vernawahlshausen
-13686;vettweiß
 13687;villmar
 13688;vilsbiburg
 13689;vilseck
@@ -11833,7 +9379,6 @@
 13710;waggonfabrik
 13711;waging
 13712;wahlbach (kr siegen)
-13713;waidhaus (gr)
 13714;wahrenholz
 13715;wakendorf
 13716;waldenburg (württ)
@@ -12054,7 +9599,6 @@
 13931;zorneding
 13932;zotzenbach
 13933;zuckerfabrik
-13934;zülpich
 13935;züttlingen
 13936;zusenhofen
 13937;zuzenhausen
@@ -12103,7 +9647,6 @@
 13980;reichenbach bei ettlingen
 13981;langensteinbach
 13982;ittersbach bahnhof
-13983;ottenhöfen west
 13984;hamburg-eidelstedt zentrum
 13985;hamburg-schnelsen
 13986;hamburg burgwedel
@@ -12146,7 +9689,6 @@
 14023;kirnbach-grün
 14024;oberharmersbach dorf
 14025;oberharmersbach-riersbach
-14026;unterentersbach
 14027;biersdorf-ort (ww)
 14028;gnarrenburg
 14029;nordsode
@@ -12266,7 +9808,6 @@
 14143;moosrain
 14144;trossingen stadt
 14145;wangerooge flugplatz
-14146;helgoland (reede)
 14147;wyk auf föhr
 14148;wittdün (amrum)
 14149;norderney
@@ -12587,7 +10128,6 @@
 14464;triptis
 14465;luckau-uckro
 14466;unterlemnitz
-14467;vitzenburg
 14468;guben
 14469;waldheim
 14470;wegeleben
@@ -12683,7 +10223,6 @@
 14560;bagenz
 14561;bahnsdorf
 14562;baitz
-14563;vejprty (gr)
 14564;berlin gesundbrunnen
 14565;balgstädt
 14566;ballstädt (gotha)
@@ -12729,7 +10268,6 @@
 14606;bindfelde
 14607;ostseebad binz
 14608;bischheim-gersdorf
-14609;berlin brandenburg flughafen
 14610;blankensee (meckl)
 14611;blankenstein (saale)
 14612;blechhammer (thür)
@@ -12852,7 +10390,6 @@
 14729;effelder (thür)
 14730;eggersdorf
 14731;eggesin
-14732;eich (sachs)
 14733;eichstedt (altm)
 14734;eickendorf
 14735;einsiedel hp gymnasium
@@ -12988,11 +10525,8 @@
 14865;groß kiesow
 14866;groß kreutz
 14867;groß laasch
-14868;groß langerwisch
 14869;groß lüsewitz
 14870;groß pankow
-14871;groß quassow
-14872;groß quenstedt
 14873;groß schönebeck
 14874;groß schwaß
 14875;großbeeren
@@ -13017,7 +10551,6 @@
 14894;grüneberg
 14895;grünhainichen-borstendorf
 14896;stralsund-grünhufe
-14897;gunzen
 14898;seelow-gusow
 14899;guthmannshausen
 14900;haarhausen
@@ -13080,8 +10613,6 @@
 14957;leipzig-holzhausen
 14958;hopfgarten (sachs)
 14959;hopfgarten (weimar)
-14960;hordorf
-14961;hoyerswerda-neustadt
 14962;hubertushöhe
 14963;huckstorf
 14964;hüttengrund
@@ -13113,7 +10644,6 @@
 14990;jößnitz
 14991;johanngeorgenstadt
 14992;altes lager
-14993;jütrichau
 14994;chemnitz kinderwaldstätte
 14995;chemnitz mitte
 14996;chemnitz-borna hp
@@ -13156,7 +10686,6 @@
 15033;klingenberg-colmnitz
 15034;klingenthal
 15035;klitschmar
-15036;klitten
 15037;klosterbuch
 15038;klosterfelde
 15039;knautnaundorf
@@ -13182,7 +10711,6 @@
 15059;krölpa-ranis
 15060;kröpelin
 15061;kronskamp
-15062;krottorf
 15063;krumhermsdorf
 15064;krumpa
 15065;kubschütz
@@ -13225,7 +10753,6 @@
 15102;legefeld
 15103;leipzig olbrichtstraße
 15104;leipzig/halle flughafen
-15105;leipzig ost
 15106;leipzig-gohlis
 15107;leipzig-heiterblick
 15108;leipzig-knauthain
@@ -13320,7 +10847,6 @@
 15197;leipzig völkerschlachtdenkmal
 15198;meuselbach-schwarzmühle
 15199;meyenburg
-15200;mierendorf
 15201;mieste
 15202;miesterhorst
 15203;miltern
@@ -13346,7 +10872,6 @@
 15223;moritzburg
 15224;mosel
 15225;mücheln (geiseltal)
-15226;mücka
 15227;mücheln (geiseltal) stadt
 15228;mühlanger
 15229;mühlbach (pirna)
@@ -13484,7 +11009,6 @@
 15361;peitz ost
 15362;perleberg
 15363;petergrube
-15364;petersdorf (meckl)
 15365;petershagen (uckerm)
 15366;petershain
 15367;petersroda
@@ -13574,15 +11098,11 @@
 15451;roitzsch (bitterf)
 15452;rosenwinkel
 15453;roßla
-15454;rostock-hinrichsdorfer straße
 15455;rostock parkstraße
-15456;rostock seehafen nord
 15457;rostock-bramow
-15458;rostock-dierkow
 15459;rostock holbeinplatz
 15460;rostock-kassebohm
 15461;rostock-marienehe
-15462;rostock toitenwinkel
 15463;rothenstein (saale)
 15464;rückersdorf
 15465;leipzig-rückmarsdorf
@@ -13732,7 +11252,6 @@
 15609;tharandt
 15610;theißen
 15611;thermalbad wiesenbad
-15612;thießen
 15613;thyrow
 15614;tiefenau
 15615;thale musestieg
@@ -13903,7 +11422,6 @@
 15780;freital-potschappel
 15781;groß dalzig
 15782;halle-silberhöhe
-15783;dresden hbf strehlener straße
 15784;chemnitz-hilbersdorf
 15785;bad lobenstein
 15786;magdeburg herrenkrug
@@ -13952,7 +11470,6 @@
 15829;ilfeld
 15830;mägdesprung
 15831;netzkater
-15832;niedersachswerfen ost
 15833;nordhausen-altentor
 15834;nordhausen-krimderode
 15835;nordhausen nord
@@ -13973,7 +11490,6 @@
 15850;kraslice (grenze)
 15851;holzhau skilift
 15852;berthelsdorf (erzgebirge) ort
-15853;kleinforst rosensee
 15854;lauterbach (rügen)
 15855;falkenhagen gewerbepark prignitz
 15856;pritzwalk west
@@ -14003,12 +11519,9 @@
 15880;altdorf (niederbay)
 15881;pfettrach
 15882;neuhausen (b landshut)
-15883;tiefenbach (b passau)
 15884;endingen (württ)
 15885;erzingen (württ)
 15886;dotternhausen-dormettingen
-15887;schömberg (b rottweil)
-15888;westerland (sylt) db autozug syltshuttle
 15889;birkenstein
 15890;frankfurt (m) flughafen regionalbf
 15891;heidenheim voithwerk
@@ -14017,23 +11530,13 @@
 15894;heidelsheim nord
 15895;gondelsheim schloßstadion
 15896;diedelsheim
-15897;kalenborn (westerw)
-15898;kasbach
 15899;hummelberg
-15900;kasbach brauerei steffens
 15901;burladingen west
 15902;basdahl kluste
 15903;st augustin markt
-15904;bonn heussallee/museumsmeile
-15905;bonn-ramersdorf
-15906;bonn-oberkassel süd/römlinghoven
 15907;königswinter fähre
-15908;bremerhaven seebäderkaje
 15909;list (sylt)
-15910;gnarrenburg nord
 15911;liederbach-süd
-15912;bad honnef stadtbahn
-15913;königswinter clemens-august-straße
 15914;bonn konrad-adenauer-platz
 15915;hangelar mitte
 15916;haubersbronn mitte
@@ -14048,50 +11551,25 @@
 15925;sinsheim museum/arena
 15926;ubstadt uhlandstraße
 15927;odenheim west
-15928;bonn stadthaus
-15929;friedrichshafen fähre
 15930;hamburg-sternschanze
 15931;schwaigern ost
 15932;leingarten ost
 15933;böckingen west
 15934;böckingen sonnenbrunnen
 15935;hohenwarth campingplatz
-15936;kahl kopp/heide
-15937;michelbach (unterfr) herrnmühle
-15938;mömbris-strötzbach
 15939;durmersheim nord
-15940;heilbronn bahnhofsvorplatz
 15941;heilbronn harmonie
 15942;heilbronn rathaus
 15943;heilbronn neckar-turm kurt-schumacher-platz
-15944;bremerhaven flugplatz
-15945;emden flugplatz
-15946;norddeich flugplatz
 15947;wössingen ost
-15948;husum
-15949;nordstrand (b husum)
 15950;alveslohe
-15951;münchen hbf arnulfstraße
 15952;bonn bertha-von-suttner-platz
-15953;bonn juridicum
-15954;glossen (b oschatz)
 15955;ostersode
 15956;hütten
 15957;münchingen rührberg
-15958;lindau hafen
-15959;bonn-bad godesberg stadthalle
-15960;helgoland (südhafen)
 15961;albisheim (pfrimm)
-15962;harxheim-zell
 15963;göllheim-dreisen
 15964;sellin (rügen) west
-15965;westerland (sylt) johann-möller-platz
-15966;westerland (sylt) alte post
-15967;westerland (sylt) waldstraße
-15968;westerland (sylt) lerchenweg
-15969;günzburg legoland
-15970;limburg (lahn) bahnhof/südseite
-15971;limburg süd ice-bahnhof
 15972;brötzingen sandweg
 15973;brötzingen wohnlichstraße
 15974;neuenbürg (enz) freibad
@@ -14103,49 +11581,31 @@
 15980;bad wildbad uhlandplatz
 15981;bad wildbad kurpark
 15982;königstein reißiger platz
-15983;kurort rathen parkplatz
-15984;obervogelgesang struppen südstraße
 15985;obervogelgesang abzweigung ebenheit
-15986;delmenhorst-annenheide
 15987;bad imnau
-15988;bad tönisstein
-15989;behringersmühle
-15990;binzen
 15991;brohl (brohltalbahn)
 15992;burgbrohl
-15993;burggaillenreuth
-15994;deinste
 15995;delmenhorst-süd
 15996;dinkelsbühl bf
 15997;dünsen dhe
 15998;engeln
-15999;epfenhofen
 16000;gammertingen europastraße
 16001;fremdingen bf
-16002;fützen
-16003;gasseldorf
 16004;gomadingen
-16005;gößweinstein
 16006;groß ippener dhe
 16007;groß mackenstedt dhe
 16008;haidkapelle
 16009;haigerloch
 16010;hammerstein
 16011;harpstedt dhe
-16012;haselünne efh
-16013;delmenhorst-hasporter damm
 16014;heiligenrode dhe
-16015;herzlake efh
 16016;kandern
 16017;kirchseelte dhe
 16018;kleinengstingen
 16019;kohlstetten
-16020;lausheim-blumegg
-16021;löningen efh
 16022;mägerkingen
 16023;marbach (b münsingen)
 16024;marienheide
-16025;muggendorf
 16026;mühringen
 16027;münsingen
 16028;niederzissen
@@ -14153,15 +11613,10 @@
 16030;oettingen (bay)
 16031;offenhausen
 16032;rangendingen
-16033;rümmingen
-16034;stelle dhe
 16035;stetten (haigerloch)
-16036;streitberg
 16037;trochtelfingen (hohenz)
 16038;viechtach
 16039;wassertrüdingen
-16040;wittlingen
-16041;wollbach (baden)
 16042;altingen (württ)
 16043;gumpenried-asbach
 16044;feuchtwangen bf
@@ -14169,241 +11624,65 @@
 16046;wilburgstetten bf
 16047;ostrach bahnhof
 16048;pfullendorf
-16049;grauschwitz flocke
 16050;ruhmannsfelden
 16051;patersdorf
 16052;teisnach
 16053;böbrach
 16054;nußberg-schönau
-16055;gstadt (wanderbahn)
 16056;schnitzmühle
 16057;metzingen-neuhausen
 16058;dettingen-mitte
 16059;bad urach wasserfall
-16060;oschatz lichtstr
-16061;oschatz körnerstr
-16062;oschatz südbf
-16063;altoschatz-rosenthal
-16064;thalheim (b oschatz)
 16065;naundorf (b oschatz)
 16066;schweta gasth
-16067;schweta bf
 16068;mügeln bf
-16069;mügeln stadt
 16070;altmügeln
-16071;nebitzschen
 16072;aachen schanz
-16073;wedel-schulau wilkomm höft
-16074;nürnberg flughafen
-16075;nürnberg hohe marter
-16076;nürnberg opernhaus
-16077;nürnberg rennweg
-16078;nürnberg schoppershof
-16079;nürnberg st-leonhard
-16080;nürnberg wöhrder wiese
-16081;nürnberg plärrer richtung hbf
-16082;nürnberg plärrer
-16083;nürnberg hbf (u-bahn)
-16084;nürnberg nordostbahnhof (u-bahn)
-16085;nürnberg rathenauplatz
-16086;nürnberg röthenbach
-16087;nürnberg rothenburger straße (u-bahn)
-16088;nürnberg-schweinau (u-bahn)
-16089;nürnberg ziegelstein
-16090;nordhausen hesseröder straße
-16091;nordhausen ricarda-huch-straße
 16092;mesch neue mühle
-16093;bonn bundesrechnungshof/auswärtiges amt
-16094;bonn museum koenig
-16095;bonn west
-16096;bonn brühler straße
-16097;bonn-gronau deutsche telekom /olof-palme-allee
-16098;bonn-gronau deutsche telekom / ollenhauerstraße
-16099;bonn-hochkreuz rheinaue
-16100;bonn-beuel rathaus
-16101;bonn obere wilhelmstraße
 16102;bonn-vilich-rheindorf adelheidisstraße
 16103;bonn-vilich-müldorf
 16104;bonn-vilich
-16105;bonn-limperich küdinghoven
-16106;bonn-limperich
-16107;bonn-oberkassel nord
 16108;bonn-oberkassel mitte
-16109;bonn-plittersdorf wurzerstraße
-16110;bonn-bad godesberg plittersdorfer straße
-16111;bonn hochkreuz/deutsches museum bonn
 16112;bonn max-löbner-straße/friesdorf
-16113;bonn robert-schuman-platz
-16114;königswinter-oberdollendorf nord
-16115;königswinter-oberdollendorf
-16116;königswinter denkmal
-16117;königswinter-longenburg
 16118;hangelar west
 16119;hangelar ost
 16120;st augustin ort
 16121;st augustin kloster
 16122;st augustin-mülldorf
-16123;bonn universität/markt
-16124;bad honnef am spitzenbach
-16125;bonn-limperich nord
-16126;bonn-ramersdorf schießbergweg
 16127;ilfeld neanderklinik
-16128;nordhausen bahnhofsplatz
-16129;münchen flughafen terminal 1
 16130;münchen flughafen terminal 2
 16131;heilbronn finanzamt
 16132;heilbronn friedensplatz
 16133;heilbronn pfühlpark
-16134;neßmersiel hafen
 16135;halfing
 16136;amerang
 16137;obing
-16138;mauthaus
-16139;dürrenwaid bahnhof
-16140;fischhaus
-16141;kalteneck
-16142;fürsteneck
-16143;röhrnbach
 16144;schierling
 16145;langquaid (b eggmühl)
-16146;krauschwitz ort
-16147;mertendorf ort
-16148;stößen zeitzer straße
-16149;wethau mitte
-16150;pirna busbf
 16151;bad schmiedeberg kurzentrum
 16152;mücka schule
 16153;niesky ödernitzer straße
 16154;uhyst gaststätte
 16155;lohsa ziegelteich
-16156;kiel wiener allee
-16157;limbach (vogtl) markt
-16158;ostritz stadt dresden
-16159;dresden industriegelände b97
-16160;görlitz-weinhübel johannes robert becher-straße
-16161;eisenheim
 16162;escherndorf
-16163;prosselsheim
-16164;seligenstadt mainschleifenbahn
-16165;volkach-astheim
 16166;söllingen kapellenstraße
-16167;radolfzell fähre
 16168;werdum feuerwehr
-16169;schurzfell
-16170;rielasingen schnaidholz
-16171;rielasingen ramsener straße
-16172;netzschkau markt
-16173;heiligengrabe feuerwehr
 16174;schmiechen albbahn
 16175;bräunlingen industriegebiet
 16176;gemmingen west
 16177;schwaigern (württ) west
 16178;leingarten mitte
-16179;konstanz konzilstraße
-16180;jakobwüllesheim
-16181;konstanz marktstätte
-16182;bonn-bad godesberg bahnhof
-16183;bonn-beuel bahnhof
-16184;bredstedt bahnhof
-16185;reicholzheim ort
-16186;münchen flughafen terminal2 ankunftebene halt22
 16187;chemnitz friedrichstraße
-16188;heidelsheim marktplatz
-16189;rastatt bahnhof ost
-16190;bubenheim
-16191;binsfeld
-16192;büsum (hafen)
-16193;konstanz sternenplatz
-16194;nürnberg hbf (bahnhofvorplatz hauptausgang)
-16195;markneukirchen sächsischer hof
-16196;siebenbrunn steinknock
-16197;muldenhütten hilbersdorf gasthof
-16198;steinpleis post
-16199;cuxhaven (fährhafen)
-16200;cuxhaven (alte liebe)
-16201;konstanz schweizer bahnhof
-16202;schweppenburg-heilbrunnen
-16203;ruit knittlinger straße
-16204;gondelsheim graf-douglas-straße
-16205;konstanz zähringerplatz
-16206;grüna poststraße
-16207;zwönitz gymnasium
 16208;brenk
 16209;gondelsheim marktplatz
-16210;chemnitz-schönau cvag-wendeanlage
-16211;heidelsheim schwimmbad
-16212;ölbronn hindenburgstraße
-16213;weiler (brohltal)
 16214;aindorf
-16215;leisnig bf
 16216;schömberg stausee
 16217;pittenhart
-16218;niederbobritzsch goldener löwe
-16219;leipzig-wahren rathaus
-16220;köln messe/deutz gleis 11-12
-16221;konstanz hafen
 16222;zielitz ort
-16223;kressbronn hafen
-16224;langenargen hafen
-16225;mühlhausen (b engen) rathaus
 16226;niebüll neg
-16227;nonnenhorn hafen
-16228;pritzwalk hainholz
-16229;rhöndorf bahnhof
-16230;siegburg bahnhof
-16231;überlingen hafen
-16232;köln kd
-16233;porz (rhein) kd
-16234;wesseling kd
-16235;bonn kd
-16236;bonn-bad godesberg kd
-16237;bad honnef (rhein) kd
-16238;unkel kd
-16239;remagen kd
-16240;linz (rhein) kd
-16241;bad breisig kd
-16242;bad hönningen kd
-16243;andernach kd
-16244;neuwied kd
-16245;koblenz kd
-16246;niederlahnstein kd
-16247;oberlahnstein kd
-16248;rhens kd
-16249;braubach kd
-16250;boppard kd
-16251;kamp-bornhofen kd
-16252;st goarshausen kd
-16253;st goar kd
-16254;oberwesel kd
-16255;kaub kd
-16256;bacharach kd
-16257;lorch (rhein) kd
-16258;assmannshausen kd
-16259;bingen (rhein) kd
-16260;rüdesheim (rhein) kd
-16261;eltville kd
-16262;wiesbaden-biebrich kd
-16263;mainz kd
-16264;koblenz moselweiß anleger
-16265;winningen (mosel) kd
-16266;kobern-gondorf sf
-16267;alken kd
-16268;brodenbach kd
-16269;moselkern kd
 16270;treis sf
-16271;cochem (mosel) kd
-16272;wächtersbach bahnhof
-16273;harlesiel anleger
-16274;harlesiel flugplatz
-16275;wasserburg hafen
-16276;wilhelmshaven helgolandkai
-16277;neuharlingersiel anleger
-16278;kappelrodeck ost
-16279;münchen flughafen terminal mvv
-16280;alzenau nord
 16281;alzenau burg
 16282;neckarbischofsheim nord
-16283;münchen flughafen besucherpark bahnhof
 16284;dagebüll kirche
 16285;haselbrunn
 16286;nenzingen
@@ -14412,18 +11691,8 @@
 16289;wahlwies
 16290;hallig hooge
 16291;hallig langeneß
-16292;schlüttsiel
 16293;pellworm
-16294;bad schachen
-16295;mainau (bodensee)
-16296;dingelsdorf
-16297;büsingen
-16298;gaienhofen
-16299;hemmenhofen
-16300;öhningen
-16301;wangen (bodensee)
 16302;linkenheim rathaus
-16303;maasbüll (b niebüll)
 16304;deezbüll
 16305;moorbekhalle
 16306;friedrichsgabe
@@ -14431,13 +11700,8 @@
 16308;meeschensee
 16309;norderstedt mitte
 16310;quickborner straße
-16311;aufenau kindergarten
-16312;karlsruhe marktplatz (kaiserstraße)
-16313;karlsruhe bahnhofsvorplatz
 16314;hochstetten grenzstraße
 16315;karlsruhe albtalbf
-16316;karlsruhe marktplatz (pyramide)
-16317;karlsruhe-neureut kirchfeld
 16318;spielberg
 16319;tuttlingen zentrum
 16320;grötzingen oberausstraße
@@ -14445,9 +11709,6 @@
 16322;rinklingen
 16323;bretten wannenweg
 16324;oldentrup
-16325;singen (htw) bahnhof
-16326;rielasingen kirche
-16327;amstetten (w) lokalbahn
 16328;eppingen west
 16329;oberderdingen-flehingen industrie
 16330;bruchweiler
@@ -14459,34 +11720,17 @@
 16336;hinterweidenthal ort
 16337;albstadt-ebingen west
 16338;ersingen west
-16339;äpfingen
-16340;ochsenhausen
-16341;reinstetten
 16342;hannover-nordstadt
 16343;hannover-ledeburg
 16344;barabein
-16345;herrlishöfen
 16346;sulmingen
-16347;wennedach
 16348;borkum reede
 16349;busenberg-schindhard
 16350;maselheim
-16351;karlsruhe durlacher tor
-16352;karlsruhe entenfang
-16353;karlsruhe-knielingen rheinbergstraße
-16354;insel reichenau
-16355;jöhstadt
-16356;jöhstadt schlössel
-16357;jöhstadt loreleifelsen
-16358;schmalzgrube
-16359;steinbach (bei jöhstadt)
-16360;schmalzgrube forellenhof
-16361;steinbach (b jöhstadt) stolln
 16362;köln-blumenberg
 16363;wörth (rhein) bürgerpark
 16364;wörth (rhein) bienwaldhalle
 16365;wörth (rhein) alte bahnmeisterei
-16366;karlsruhe mühlburger tor
 16367;neidenfels
 16368;hinterweidenthal ost
 16369;unteröwisheim martin-luther-straße
@@ -14504,98 +11748,28 @@
 16381;list (sylt) dünenstraße
 16382;list mellhörn
 16383;list süderhörn
-16384;morsum skellinghörn
 16385;möskental
-16386;munkmarsch mitte
-16387;norddörfer schule
 16388;rantum campingplatz
 16389;rantum nord
 16390;rantum seeheim
 16391;rantum süd
 16392;samoa fkk-strand
 16393;schauinsland
-16394;sylt-ost sportanlage
-16395;tinnum gemeindehaus
-16396;tinnum königskamp
-16397;tinnum siedlung
 16398;wassertal sansibar
 16399;wenningstedt hauptstraße/friesenhof
-16400;wenningstedt (sylt) siedlung
-16401;westerland (sylt) campingplatz
-16402;westerland (sylt) fkk-strand
-16403;westerland (sylt) marinesiedlung
-16404;westerland (sylt) norderstraße
-16405;westerland (sylt) stadtmitte
-16406;westerland zob
 16407;list mövengrund
 16408;wörth (rhein) rathaus
 16409;wörth (rhein) badallee
 16410;wörth (rhein) badepark
-16411;keitum bahnhof
-16412;grenzach grenzacher horn
-16413;grenzach im rippel
-16414;grenzach hornrain
-16415;grenzach bärenfelsstraße
-16416;grenzach seidenweg
-16417;grenzach sparkasse
-16418;singen (hohentwiel) friedrich-ebert-platz
-16419;wyhlen schulzentrum
-16420;wyhlen hutmattenstraße
-16421;wyhlen hebelschule
-16422;wyhlen engeltal
-16423;wyhlen siedlung
 16424;haltingen zentrum
-16425;haltingen bahnhof
-16426;haltingen markgräflerstraße
-16427;haltingen weinbergstraße
-16428;weil am rhein berliner platz
-16429;weil am rhein friedhof
-16430;weil am rhein grün 99/laguna
-16431;weil am rhein läublinpark
-16432;weil am rhein marktstraße
-16433;steinbach (b jöhstadt) wildbach
-16434;weil am rhein otterbach zoll
-16435;weil am rhein rathaus
-16436;weil am rhein turmstraße
-16437;weil am rhein vitra
-16438;rheinfelden (d) bürgerheim
-16439;rheinfelden (d) busbahnhof
-16440;rheinfelden (d) deutscher zoll
-16441;singen (htw) heidenbühl
-16442;rheinfelden (d) eichamtstraße
-16443;rheinfelden (d) friedrichplatz
-16444;rheinfelden (d) gewerbeschule
-16445;rheinfelden (d) goethestraße
-16446;rheinfelden (d) hebelstraße
-16447;rheinfelden (d) josefskirche
-16448;rheinfelden (d) kreiskrankenh
-16449;rheinfelden (d) müßmattstraße
-16450;rheinfelden (d) oberrheinplatz
-16451;rheinfelden (d) post
-16452;rheinfelden (d) schwalbenstraße
-16453;rheinfelden (d) friedhof
-16454;rheinfelden (d) schillerschule
-16455;rheinfelden (d) werderstraße
-16456;rheinfelden (d) seniorenwohng
-16457;rheinfelden (d) kronenstraße
-16458;grenzach gleusen
-16459;grenzach turnhalle
 16460;tessin west
 16461;herzhorn
-16462;helbra
 16463;singen industriegebiet
 16464;zeutern sportplatz
 16465;rostock thierfelder straße
 16466;heilbronn-böckingen berufsschulzentrum
 16467;frankfurt (main) messe
-16468;singen (htw) rielasinger-straße
-16469;singen (htw) markuskirche
-16470;rielasingen zoll
-16471;rielasingen mühle
-16472;singen (htw) julius-bührer-st
 16473;albrechtshof
-16474;augustusburg bergstation
-16475;erdmannsdorf talstation
 16476;potsdam-babelsberg
 16477;bergfelde (b berlin)
 16478;gronau (westf) gr
@@ -14608,7 +11782,6 @@
 16485;elstal
 16486;fredersdorf (b berlin)
 16487;teltow stadt
-16488;genshagener heide
 16489;potsdam griebnitzsee
 16490;halle dessauer brücke
 16491;halle rosengarten
@@ -14631,19 +11804,9 @@
 16508;mühlenbeck-mönchmühle
 16509;todtnau
 16510;ilfeld schreiberwiese
-16511;niedersachswerfen ilfelder straße
-16512;niedersachswerfen herkulesmarkt
 16513;ilfeld bad
 16514;neuendorf (hiddensee)
-16515;schaprode
-16516;stralsund hafen
 16517;neuenhagen (berlin)
-16518;bad doberan stadtmitte
-16519;ostseebad ahrenshoop mitte
-16520;ostseebad dierhagen (darß)
-16521;ostseebad prerow hafenstraße
-16522;ostseebad wustrow mitte
-16523;ostseebad zingst zentrum
 16524;petershagen nord
 16525;röntgental
 16526;saarmund
@@ -14654,18 +11817,14 @@
 16531;strausberg stadt
 16532;vitte (hiddensee)
 16533;wieck (darß)
-16534;born (darß) waldschänke
 16535;wildau
 16536;zepernick (bernau)
 16537;zeuthen
 16538;seegefeld
 16539;cottbus-willmersdorf nord
 16540;lehnitz
-16541;oberhof rondell/rennsteiggarten
-16542;oberhof platz des friedens/busbf
 16543;baddeckenstedt bf
 16544;hechingen landesbahn
-16545;köln messe/deutz gleis 9-10
 16546;kirchweidach
 16547;maximiliansau west
 16548;maxau
@@ -14676,25 +11835,12 @@
 16553;diekjen-deel
 16554;puan klent (sylt)
 16555;hörnum hafen
-16556;puttgarden schiffsanleger
-16557;archsum
-16558;braderup (wenningstedt)
 16559;keitum schnittis eck
 16560;kampen mitte
 16561;list fähre
-16562;munkmarsch hafen
-16563;morsum kleinmorsum
 16564;keitum parkplatz west
-16565;tinnum mitte
-16566;wenningstedt mitte
-16567;straßberg-glasebach
 16568;kampen (sylt) hamburger kinderheim
 16569;vogelkoje (sylt)
-16570;westerheide-blidsel
-16571;westerland (sylt) nordseeklinik
-16572;tinnum (sylt) einkaufszentrum
-16573;tinnum (sylt) neuapostolische kirche
-16574;westerland (sylt) wenningstedter weg
 16575;tinnum (sylt) culemeyerstraße
 16576;westerland (sylt) drk
 16577;bruchsal schloßgarten
@@ -14711,9 +11857,6 @@
 16588;weil im schönbuch röte
 16589;weil im schönbuch untere halde
 16590;dettenhausen
-16591;niebüll db autozug syltshuttle
-16592;vechta-stoppelmarkt
-16593;künzelsau bf
 16594;ahlbeck ostseetherme
 16595;heringsdorf neuhof
 16596;stubbenfelde
@@ -14728,7 +11871,6 @@
 16605;maulbronn west
 16606;neuhaus am rennweg
 16607;berlin-schulzendorf
-16608;berlin alexanderplatz (s)
 16609;berlin anhalter bf
 16610;berlin attilastraße
 16611;berlin baumschulenweg
@@ -14742,13 +11884,11 @@
 16619;berlin feuerbachstraße
 16620;berlin frankfurter allee
 16621;berlin gehrenseestraße
-16622;berlin gesundbrunnen (s)
 16623;berlin grünbergallee
 16624;berlin hackescher markt
 16625;berlin humboldthain
 16626;berlin jannowitzbrücke
 16627;berlin landsberger allee
-16628;berlin hbf (s-bahn)
 16629;berlin mehrower allee
 16630;berlin mexikoplatz
 16631;berlin nordbahnhof
@@ -14758,7 +11898,6 @@
 16635;berlin ostkreuz
 16636;berlin plänterwald
 16637;berlin poelchaustraße
-16638;berlin potsdamer platz (s)
 16639;berlin prenzlauer allee
 16640;berlin priesterweg
 16641;berlin raoul-wallenberg-straße
@@ -14796,7 +11935,6 @@
 16673;berlin-lichtenrade
 16674;berlin-lichterfelde west
 16675;berlin-mahlsdorf
-16676;berlin südkreuz (s)
 16677;berlin-marienfelde
 16678;berlin-marzahn
 16679;berlin-neukölln
@@ -14809,7 +11947,6 @@
 16686;berlin-schlachtensee
 16687;berlin-schönholz
 16688;berlin-spindlersfeld
-16689;berlin-tegel (s)
 16690;berlin-tempelhof
 16691;berlin-tiergarten
 16692;berlin-waidmannslust
@@ -14820,7 +11957,6 @@
 16697;berlin-wuhlheide
 16698;berlin-zehlendorf
 16699;bernau-friedenstal
-16700;berlin jungfernheide (s)
 16701;berlin eichborndamm
 16702;berlin karl-bonhoeffer-klinik
 16703;berlin alt-reinickendorf
@@ -14833,39 +11969,19 @@
 16710;berlin messe nord/icc (witzleben)
 16711;berlin westend
 16712;berlin heidelberger platz
-16713;berlin-lichterfelde ost (s)
 16714;berlin-lankwitz
 16715;berlin südende
 16716;berlin westhafen
 16717;berlin beusselstraße
-16718;herzogenrath (gr)
-16719;forst (gr)
-16720;grambow (gr)
-16721;frankfurt (oder) (gr)
-16722;schöna (gr)
-16723;tantow (gr)
-16724;zittau (gr)
 16725;berlin-wedding
-16726;berlin busbf (zob) am funkturm
-16727;bad orb busbf
-16728;wolfsburg busbf
-16729;coburg bahnhof/zob
-16730;bad neustadt (saale) busbahnhof
-16731;bad staffelstein thermalbad
 16732;berlin sonnenallee
 16733;berlin messe süd (eichkamp)
 16734;berlin heerstraße
 16735;berlin olympiastadion
 16736;berlin-pichelsberg
-16737;lichtenfels bahnhof
-16738;erfurt busbahnhof
-16739;waldenburg-hohebuch
-16740;kiel zob
-16741;schwerin marienplatz
 16742;berlin-lichterfelde süd
 16743;berlin osdorfer straße
 16744;berlin-schöneberg
-16745;schwerin platz der jugend
 16746;berlin julius-leber-brücke
 16747;ittersbach rathaus
 16748;nürtingen-vorstadt
@@ -14877,141 +11993,54 @@
 16754;plauen
 16755;pößneck
 16756;leipzig
-16757;elsterwerda
 16758;hiddensee
 16759;hannover messe
-16760;düsseldorf flughafen
-16761;groß gerau
 16762;lauf (pegnitz)
 16763;schwaig (b nürnberg)
 16764;eschweiller
 16766;kassel
 16767;berlin flughafen tegel
-16768;bad abbach ort
-16769;dettelbach ort
-16770;bonn hbf (tief)
 16771;dresden-neustadt gleis 10
-16772;stuttgart hbf (tief)
-16773;frankfurt hbf (tief)
-16774;hamburg-harburg (s)
-16775;berlin hbf (tief)
-16776;kassel hbf (tief)
-16777;münchen hbf gleis 27-36
-16778;münchen hbf gleis 5-10
-16779;münchen hbf (tief)
-16780;stolberg hbf gleis 27 (rheinl)
 16781;nürnberg frankenstadion sonderbahnsteig
-16782;hamburg hbf (s-bahn)
-16783;hamburg-altona (s)
 16784;bensersiel ne
 16785;hildesheim gbf
 16786;stolberg (rheinl) gbf
-16787;neustadt (holst) gbf
-16788;annonay
 16789;ste-florine lycée claude favard
 16790;bantzenheim
-16791;bertren
-16792;blazy
 16793;bienville
 16794;la-croix-st-bonnet
-16795;bénodet
-16796;luxembourg thor
 16797;baud
 16798;st-louis (moselle)
 16799;henridorff
-16800;danne-et-quatre-vents
 16801;froissy rn
-16802;beaupuy
-16803;brétigny ba 217
-16804;brunoy wittl
 16805;bar-sur-aube hôtel de ville
 16806;blesme centre
 16807;abrest—les dollots
-16808;villiers-sur-marne beauséjour
-16809;bettembourg frontière
-16810;bretenoux—biars croisement
 16811;bourges aéroport
 16812;balazuc rd
 16813;chomérac
-16814;calais terminal
 16815;cormenon les charmilles
-16816;cern blandonnet
-16817;la cluses et mijoux
-16818;la ferté-gaucher
-16819;la ferté-gaucher centre
-16820;corgoloin transco
-16821;jouy-sur-morin monument
-16822;jouy-sur-morin eustache lenoir
-16823;jouy-sur-morin champgoulin
-16824;coulommiers gare
-16825;corbeil essonnes a croizat
-16826;damville place de la halle
-16827;devecey
-16828;dore l’église
-16831;habas
 16832;viviez la boudie
-16833;dracy saint-loup
-16834;dracy saint-loup mairie
-16835;drancy centre
-16836;draveil église
-16837;nonant centre
-16838;aube centre rn 26
 16839;durdat-larequille
 16840;agen université
-16841;epinay-sous-sénart
-16842;gennevilliers les grésillons
-16843;erquelinnes
-16844;etampes croix de vernailles
 16846;sainte-eugénie-de-villeneuve
-16847;montmorillon lycée professionnel agricole jean-marie bouloux
-16848;eyrein
-16849;fouesnant beg meil
-16850;villiers-sur-marne friedberg
-16851;fourchette de bry
-16852;charles-de-gaulle friedland
-16853;clermont dollet
-16854;fret centre
-16855;la ferté-gaucher
-16856;fouesnant centre
 16857;cambes village
-16858;feniers
 16859;ceint-d’eau village
-16860;fouesnant
 16861;l’hôpital village
 16862;le bourg
 16863;livernon gendarmerie
 16864;rudelle mairie
 16865;thémines
-16866;ste-christie casteljaloux
 16867;fix
 16868;espère
 16869;lignareix
 16870;petit-laval
 16871;blazac
-16872;espère
-16873;la châtre
-16874;félines la remise
-16875;fontanieres mairie
-16876;foyer des bruyeres
-16877;pierre buffiere champ de foire
-16878;ajain
 16879;civray le grand entrevin
-16880;labastide
-16881;wisembach
-16882;freyssenet
-16883;gemaingoutte
-16884;le giron bertrimoutier
-16885;lahitte
-16886;avensac
-16887;gimat
-16888;bourret
-16889;saint sauvy
-16891;atlb paris nord
 16892;anos pn
 16893;bagiry
 16894;bertren abri
 16895;bertren nord
-16896;grâce-de-dieu
 16897;bertren sud
 16898;cazaux-layrisse
 16899;chaum pont
@@ -15021,377 +12050,61 @@
 16903;gouaux-de-luchon
 16904;loures-barousse
 16905;saléchan embranchement
-16906;revel lycée auriol
-16907;mirande café le glacier
-16908;villecomtal les castors
 16909;pratviel la ferme
 16910;siradan
 16911;la pomarède
 16912;peyrens
 16913;pont-crouzet
-16914;chis
-16915;orleix
-16916;saint-martin gers
-16917;gabarret
-16918;place gounot
-16919;goderville
-16920;gourzon
-16921;castelnau estretefond mairie
-16922;marroule
-16923;embt compolibat d911/d26
-16924;le houga
 16925;saint-amancet
 16926;viviers-lès-montagnes la pierre plantée
-16927;saint-hilaire bonneval la roselle
-16928;naves tarn
-16929;villiers-sur-marne georges demessy
-16930;la grave carrefour
-16931;gargenville mairie
-16933;saint-avit
-16936;rougnat
-16937;la chaise dieu
-16938;la chaise dieu école hôtelière
-16939;hôpital jean rostand
-16940;château du loir racan
-16941;château du loir collège berce
 16942;la chomette
-16943;henvic
-16944;henvic pont de la corde
-16945;fourques pont de sable
-16946;sainte marthe
-16947;le clavier
-16948;houeilles
-16949;lapeyrade
-16950;lamure collège
-16951;imbsheim
-16952;onet le château
 16953;boé la couronne
-16954;bobigny normandie niemen
-16955;mt de marsan poincaré
-16956;jouy morin
-16957;villeneuve 05
-16958;jonzac gare routière
-16959;pons gare routière
-16961;barbezieux piscine
-16962;paris place loulou-gasté
-16963;paris pereire saussure
-16964;tocqueville
-16965;paris ampère wagram
-16966;paris jouffroy tocqueville
-16967;canfranc
-16968;fougères carnot
 16969;godenvillers
-16970;jean pierre timbaud
-16971;juvisy-sur-orge mairie
-16972;kirrwiller
-16973;schoenenbourg
-16974;laferte-sur-aube
-16975;alba
 16976;lablachère
-16977;le coudray montceaux justice
-16978;lognes cours des lacs
 16979;coubladour
-16980;lauterbourg
-16981;le guidon
-16983;gaillac
-16984;naucelle
-16985;rodez
 16986;le franceix
-16987;tanus
 16988;saint-lager-bressac
-16989;languidic
-16990;saint-père place de la mairie
-16991;bazoches office de tourisme
-16992;aubin lep
-16993;lichemialle
-16994;la passerelle
 16995;laon station service
-16996;laon collège lenain
-16997;laon lycée paul claudel
-16998;laon lycée méchain
-16999;laon charlemagne
-17000;longeau
-17001;la pacaudière
-17004;les quatre vents
-17005;bourg lastice
-17006;la saunière la correspondance
-17007;letra gabodiere
 17008;lanthénas
-17009;liart centre
-17010;saint-martin d’hères
 17011;marquixanes
 17012;mariol
 17013;la combelle
-17014;meursault rue du 11 novembre
-17015;blanc mesnil centre
-17016;montgeron église
-17017;tremblay-en-france marguilliers
-17018;ministere des finances popb
-17019;min de rungis la maree
-17020;cormery place du mail
-17021;meaulne place centrale
-17022;meulan place du vexin
-17023;maison neuve
 17024;grandrieux place de la mairie
-17025;porte-maillot-rer c
 17026;mainbresson centre
-17027;le cheix-sur-morge
 17028;morre
 17029;chivres-en-laonnois marais-de-chivres
 17030;arenc–euroméditerranée
-17031;mont saint-aignan campus
-17032;massena
-17033;marcel sembat
-17034;noisy le grand mont d’est rer
-17035;lagny thorigny noctilien
-17036;chessy noctilien
-17037;porte de bagnolet noctilien
-17038;republique noctilien
-17039;neuilly plaisance noctilien
-17040;montevrain noctilien
-17041;nouvelle amsterdam
-17042;fontenay le perreux noctilien
-17043;ville evrard noctilien
-17044;emerainville pontault-combault noctilien
-17045;val de fontenay noctilien
-17046;gretz armainvilliers ctre noct
-17047;rosny-sous-bois noctilien
-17048;rosny bois perrier noctilien
-17049;val d’europe serris montévrain noctilien
-17050;collegien noctilien
-17051;bussy saint georges noctilien
-17052;saint thiebault des vignes noctil
-17053;ozoir la ferriere centre noct
-17054;neuenburg baden frontière
-17055;aristide briand noctilien
-17056;aerogare orly ouest noctilien
-17057;aerogare orly sud noctilien
-17058;noisy champs rer descartes
-17059;viry chatillon noctilien
-17060;grigny centre noctilien
-17061;evry courcouronnes noctilien
-17062;bras de fer noctilien
-17063;corbeil essonne noctilien
-17064;villeneuve saint georges noctilie
-17065;vigneux-sur-seine noctilien
-17066;juvisy noctilien
-17067;condat centre equestre
-17068;allègre maison de retraite
-17070;malaguet
-17071;darsac lotissement
-17072;gannat lycée eiffel
-17073;gannat lycée sainte procule
-17074;reugny rue de la bascule
-17075;la ville gozet square henri dunant
-17076;les ancizes saint-georges bourg
-17077;les ancizes saint-georges usine
-17078;saint-georges de mons rue des écoles
-17079;le puy-en-velay hôpital émile roux
 17080;halte de fontanil–lycée de drap
-17081;noisiel le luzard rer
-17082;bezons grand cerf noctilien
-17083;courbevoie becon noctilien
-17084;la garenne colombes noctilien
-17085;sartrouville noctilien
-17086;conflans-fin-d’oise noctilien
-17087;eragny-sur-oise noctilien
-17088;neuville universite noctilien
-17089;conflans sainte honorine noctilien
-17090;houilles noctilien
-17091;residence du parc essec noctil
 17092;néris-les-bains
-17093;communay stade
-17094;ordener marx dormoy
 17095;ste-florine place françois mitterrand
-17096;aerogare d’orly sud
-17097;paris bastille
-17098;port bou
-17099;porte de la chapelle
-17100;place de la chapelle
-17101;saint-pourcain-sur-sioule
-17102;pyramide de juvisy
-17103;porte de paris
-17104;porte de pantin
-17105;parc du tremblay
-17106;saarbrücken thor
-17107;kortrijk thor
-17108;imperia thor
-17109;london thor
-17110;peaugres
-17111;place d’italie
-17112;porte d’italie
-17113;paul langevin
-17114;pyrimont chanay
-17115;porte des matelots
-17116;pierre edouard
 17117;dorat la chauprillade
-17118;mairie du 10ème
-17119;pasteur
-17120;groupe scolaire pasteur
-17121;pétange
-17122;porte de versailles
-17123;la petite villedieu
-17124;les pyramides
-17125;meulan arquebuse
 17126;amiens cité universitaire
-17127;amiens scolaire
 17128;beauvais lycée félix faure
 17129;beauvais franc marché
-17130;quai de la gare
-17131;quincy-sous-senart
-17132;quevy
-17133;romorantin – gare routière
-17134;revel
-17135;franconville croix rouge
-17136;rachecourt-sur-marne
-17137;reaumur arts et metiers
-17138;les ramassiers
-17139;ruffey le château
-17140;venere
-17141;cresancey
-17142;marnay
-17143;cult
 17144;romorantin plaisance
-17145;vierzon bibliothèque
-17146;rochejean
-17147;vaudagne
-17148;balard
-17149;roquefort walibi
-17150;rodange
-17151;nérac centre ville
-17152;andiran
-17153;mézin
-17154;poudenas
-17155;sos
-17156;gueyze
-17157;saint-pe saint-simon
-17158;labastide d’armagnac
-17159;saint justin
-17160;la freche
-17161;villeneuve de marsan
-17162;saint-criq villeneuve
-17163;rue des vignes
-17164;bougue
-17165;reaumur sebastopol
 17166;laon gare routière
 17167;la garde de dieu
-17168;ris-orangis jean jaurès
-17169;ris-orangis da
-17170;rioz
-17171;rennes littré
-17172;rougnat centre
 17173;rompon les-fonts-du-pouzin
-17174;rosteig
-17175;rouvroy-sur-marne
-17176;roueyre
-17177;rond point europe
 17178;arrest usine mélius
-17179;carrefour 18 juin 40
-17180;rue de rennes saint germain
-17181;roissypôle
-17182;porte asnieres
-17183;reugny rn
-17184;rupt
-17185;ribeauvillé
 17186;rozoy-sur-serre salle des fêtes
-17187;saint-angel
-17188;santec
-17189;saint-pierre echaubrognes centre
-17190;sevran beaudottes luther king
 17191;saint-eble
-17192;saint-cernin
-17193;sarrebourg lp messmer
-17194;sarrebourg mairie
-17195;sarrebourg abri route de phalsbourg
-17196;sarrebourg wilson
-17197;selongey école ménagère
-17198;selongey patenee
-17199;til chatel poste
-17200;til-châtel perdrixière
 17201;st-didier-sous-aubenas
-17202;surmoulin
-17203;lognes collège du segrais
 17204;le subdray lycée agricole
-17205;saint-etienne du madrillet
-17206;serrigny
-17207;saulieu
-17208;portet—saint-simon
-17209;pins-justaret
-17210;saverdun
-17211;saint-jean de verges
-17212;ste-florine
-17213;saint-paul
-17214;tarascon-sur-ariège
-17215;luzenac
 17216;liesse notre dame centre
-17217;serres (haute-loire)
-17218;senlis avenue de creil
-17219;senlis arènes
-17220;creil valois
 17221;saint-martin du touch
-17222;sablons pont de sablons
-17223;saint germain odeon
-17224;les sablons
-17225;saint-sauves-d’auvergne bourg
-17226;rosières centre
-17227;liesse gendarmerie
-17228;boussy saint-antoine le stade
-17229;serrigny transco
-17230;sevres lecourbe
-17231;châtelet
-17232;italie tolbiac
-17233;aéroport cdg t
 17234;maleville—barbet
-17235;aéroport cdg t
 17236;le bruel bel-air
-17237;saint-maur
-17238;miramont trouette
-17239;laguian mazous
-17240;aéroport cdg t
 17241;lacassagne
 17242;escondeaux
-17243;rieucros
-17244;lavelanet lycée
 17245;la bastide-de-bousignac
 17246;faycelles
 17247;la tour-de-faure
 17248;savanac
-17249;château d’eau
-17250;chateldon
 17251;floirac cours
 17252;la roque-bouillac
 17253;cuzac enlet
-17254;aubin cerons croisement
-17255;fer a cheval noctilien
-17256;les tilleuls noctilien
-17257;franche comte noctilien
-17258;torcy collège jean monnet
-17259;le fief d’artois
-17260;le toec
-17261;torcy rer
-17262;trilport église
-17263;trilport parc
-17264;terroir de france cinecite
-17265;trilport
 17266;le treuil
-17267;atrium
-17268;tournon-sur-rhône
-17269;corbeil essonnes tarterets
-17270;thivet
-17271;colpo
-17272;cazaubon
-17273;capdenac le haut cabannes
-17274;lanespede
-17275;lhez
-17276;mascaras d5-n117
-17277;père
 17278;gourdan-polignan lycée
-17279;pinas
-17280;saint-laurent de neste centre
-17281;saint-paul de broca
-17282;saint-paul de neste
-17283;castelnaudary route de revel
-17284;labège payssière
 17285;bouillac
 17286;canabols embranchement
 17287;cornuejouls abri
@@ -15406,145 +12119,17 @@
 17296;le rouziet parc aventure
 17297;luscan pont
 17298;moustajon
-17299;courbassil
-17300;ruites
 17301;tarascon espace mitterand
 17302;gimont halles
 17303;léguevin centre
 17304;pujaudran centre
-17305;boussens usine
-17306;erce mairie
-17307;lacourt centre
-17308;mane intermarché
-17309;oust pont
-17310;roquefort le fourc
-17311;salies du salat thermes
-17312;soueix place
-17313;bagneres de bigorre lycée blanche odin
-17314;barbazan débat église
-17315;séméac alsthom porte sud
-17316;veille aure resitel
-17317;saint-lary soulan néouvielle
-17318;guchen église
-17319;aragnouet mairie
-17320;mazamet lycée
-17321;sabo croisement national départemental
-17322;saint-pons foirail
 17323;saint-paul-cap-de-joux centre
 17324;albine croisement n112/d88
-17325;courniou croisement national départemental
-17326;lacabarede national départemental
-17327;semalens centre
-17328;loupiac café
-17329;rieupeyroux
-17330;la peyriere
-17331;morlhon le haut
-17332;memer
-17333;parisot place du 19 mars
-17334;caylus centre
-17335;septfonds salle des fêtes
-17336;la primaube
-17337;la mothe
-17338;naucelle rn
-17339;pont de blaye
-17340;le garric mairie
-17341;l’hermet
-17342;saint-martial 12 rn
-17343;avenue de gaumont
-17344;la trivalle 12
-17345;erce
-17346;lacourt
-17347;mérens-les-vals
-17348;porté-puymorens
-17349;villefranche-sur-cher gr
-17350;villepinte espace v
-17351;vecqueville
-17352;vougeot rn 74
-17353;villecomtal
-17354;vigneux patt d’oie
-17355;verfeil
-17356;dréfféac
-17357;coudes ville
-17358;villepinte le clos montceleux
 17359;hameau de vincy
 17360;andorra la vella
-17361;voray-sur-l’ognon
-17362;viry-chatillon—blazy
-17363;verneuil faisanderie
-17364;convention lecourbe
-17365;volontaire vaugirard
-17366;convention vaugirard
-17367;lavilledieu zone d’activité
-17368;chêne bourg
-17369;bouligny
-17370;bruyères
-17371;rambervilers
-17372;domgermain
-17373;frebecourt
-17374;vaucouleurs
-17375;darnieulles
-17376;marville
-17377;villette
-17378;cocheren
-17379;griesbach
-17380;avricourt
-17381;gondrexange
-17382;guéret gare routière
-17383;la montané
-17384;welferding
-17385;yvecrique mairie
-17386;le cygne d’enghien
-17387;st-yorre
-17388;st-yorre cité de la verrerie
-17389;gray
-17390;yves farges
-17391;mont meurthe rue de lorraine
-17392;vallois centre
-17393;domgermain bois le comte
-17394;frebecourt
-17395;vaucouleurs place poirel
-17396;bouligny saint-pierre
-17397;chambley carrefour
-17398;jarny hôtel de ville
-17399;dommartin franould
-17400;peccavillers
-17401;saulxures-sur-moselotte lac
-17402;saulxures-sur-moselotte lep
-17403;saulxures-sur-moselotte place claude
-17404;bussang
-17405;remanvillers
-17406;saint-maurice moselle mairie
 17407;lamerey
-17408;ugny meurthe et moselle
-17409;anzeling carrefour
-17410;budange
-17411;falck rue principale
 17412;hargarten-aux-mines
-17413;metzervisse église
-17414;cocheren village
-17415;griesbach moulin
 17416;mertzwiller monument aux morts
-17417;reichshoffen sapin
-17418;schwangerbach
-17419;diedendorff
-17420;sarre-union place de la république
-17421;schopperten lotissement
-17422;schopperten mairie
-17423;avricourt café saint-nicolas
-17424;avricourt rue de lorraine
-17425;gondrexange centre
-17426;réchicourt le château centre
-17427;gosselming poste
-17428;epiez-sur-chiers
-17429;flabeuville carrefour
-17430;marville carrefour
-17431;vezin
-17432;villette moulin battin
-17433;agen
-17434;albine
-17435;anglars
-17436;argèles-gazost
-17437;arzviller
 17438;sains-morainvillers
 17439;montigny d938 général leclerc (oise)
 17440;maignelay pharmacie
@@ -15552,24 +12137,13 @@
 17442;abbémont
 17443;ayencourt
 17444;montdidier lep
-17445;roye st-mard
-17446;roye ces
-17447;roye salengro
 17448;roye centre
 17449;roye agri santerre
-17450;montdidier place doumer
-17451;montdidier place foch
 17452;montdidier place faidherbe
-17453;courcelles (somme)
-17454;péronne lycée mendès france
-17455;mazancourt
 17456;boucly
 17457;reichshoffen usines
 17458;salzburg hbf
 17459;duivendrecht
-17476;montdidier
-17478;roye
-17481;rozoy-sur-serre
 17484;bolzano/bozen
 17489;orte
 17491;feldkirch
@@ -15579,7 +12153,6 @@
 17497;graz hbf
 17498;judenburg
 17499;klagenfurt hbf
-17500;linz/donau hbf
 17501;steyr
 17502;wels hbf
 17503;brno hl.n.
@@ -15597,12 +12170,10 @@
 17516;odense st.
 17517;roskilde st.
 17518;gdańsk główny
-17519;łódź kaliska
 17520;göteborg central
 17521;halmstad central
 17522;helsingborg central
 17523;malmö central
-17524;chalon-sur-saône gare routière
 17529;wilderswil
 17530;stäfa
 17531;stans
@@ -15610,9 +12181,7 @@
 17533;lungern
 17534;kloten
 17535;horgen
-17536;davos dorf dkb
 17537;brig
-17538;bruxelles-midi eurostar
 17540;amstetten nö
 17541;bad ischl
 17542;bad gastein
@@ -15647,21 +12216,10 @@
 17580;zoetermeer
 17581;dronten
 17582;st. valentin
-17583;berlin hbf (europaplatz)
 17584;kraków główny
-17585;kraków główny (bus)
 17587;praha
-17588;praha hl.n. wilsonova
-17589;münchen zob (hackerbrücke)
-17590;mannheim hbf (busbf)
-17591;leipzig hbf (tief)
-17592;freiburg (breisgau) zob
-17593;halle hbf ernst-kamieth-straße (saale)
 17594;fredericia st.
 17595;tinglev st.
-17596;rostock albrecht-kossel-platz
-17597;stuttgart hbf (tief) +
-17598;ravensburg bhf (sev)
 17599;melk
 17600;lambach
 17601;attnang-puchheim
@@ -15738,14 +12296,12 @@
 17672;hermagor
 17673;kaltenbach-stumm im zillertal
 17674;kirchbichl
-17675;kötschach-mauthen
 17676;krems an der donau
 17677;langkampfen
 17678;stans bei schwaz
 17679;terfens-weer
 17680;uderns im zillertal
 17681;volders-baumkirchen
-17682;wien bahnhof meidling (eichenstraße)
 17683;bad kreckelmoos
 17684;braunau/inn
 17685;brixen im thale
@@ -15776,18 +12332,13 @@
 17710;graz köflacher bahnhof
 17711;graz webling
 17712;graz wetzelsdorf
-17713;wien schedifkaplatz (lokalbahn)
 17714;reutte in tirol schulzentrum
-17715;wien dörfelstraße (meidling bahnhof)
 17716;bichlbach almkopfbahn
 17717;laimach regionalmuseum
 17718;salzburg taxham europark
 17719;salzburg aiglhof
 17720;salzburg mülln-altstadt
 17721;salzburg sam
-17722;wien hütteldorf (u4)
-17723;wien bahnhof meidling (u6)
-17724;landeck-zams bahnhof (bussteige a-e)
 17725;bischofshofen
 17726;landeck-zams
 17727;spittal-millstättersee
@@ -16234,11 +12785,8 @@
 18168;haren-zuid
 18169;liestal
 18170;sissach
-18171;dornach (ch)
 18172;tavannes
 18173;laufen
-18174;andermatt (gemsstockbahn)
-18175;grindelwald bgf
 18176;tramelan
 18177;saignelegier
 18178;oensingen
@@ -16247,22 +12795,9 @@
 18181;stein-säckingen
 18182;laufenburg
 18183;koblenz bahnhof
-18184;kreuzlingen bernrain bahnhof
-18185;frick bahnhof
-18186;visp bahnhof nord
-18187;belp post
-18188;rotkreuz bahnhof nord
-18189;balsthal bahnhof
-18190;dornach-arlesheim bahnhof
-18191;schönenwerd so bahnhof
 18192;rolle
 18193;renens vd
 18194;vevey
-18195;morges cgn
-18196;vevey-marché
-18197;vevey (funi)
-18198;martigny gare
-18199;rolle cgn
 18200;chateau-d’oex
 18201;rougemont
 18202;saanen
@@ -16270,22 +12805,14 @@
 18204;aigle
 18205;bex
 18206;st-maurice
-18207;leysin tlsa
 18208;sion
 18209;sierre/siders
-18210;sierre/siders smc
 18211;leuk
-18212;fiesch fe
-18213;leuk bahnhof
-18214;fürgangen-bellwald talstation
+18214;fürgangen-bellwald
 18215;mörel
 18216;st. niklaus
 18217;täsch
 18218;zermatt
-18219;zermatt ggb
-18220;leysin-feydey gare
-18221;sion poste/gare
-18222;sierre poste/gare
 18223;sursee
 18224;unterkulm
 18225;menziken
@@ -16294,12 +12821,8 @@
 18228;birmensdorf zh
 18229;affoltern am albis
 18230;birr
-18231;cham (ch) see
-18232;wohlen ag bahnhof
-18233;sursee bahnhof
 18234;zürich flughafen
-18235;zürich hb szu
-18236;küsnacht zh
+18236;küsnacht
 18237;erlenbach zh
 18238;meilen
 18239;männedorf
@@ -16327,26 +12850,15 @@
 18261;killwangen-spreitenbach
 18262;schlieren
 18263;regensdorf-watt
-18264;lachen zsg
-18265;küsnacht zsg
-18266;erlenbach zsg
-18267;meilen zsg
-18268;männedorf zsg
-18269;richterswil zsg
-18270;thalwil zsg
 18271;kilchberg bendlikon
-18272;turgi bahnhof
 18273;romont
 18274;bulle
 18275;st-imier
 18276;le locle
-18277;st-imier smts
 18278;kerzers
 18279;ins
-18280;kerzers bahnhof
 18281;küssnacht am rigi
 18282;brunnen
-18283;brunnen bahnhof
 18284;flüelen
 18285;altdorf
 18286;erstfeld
@@ -16357,17 +12869,12 @@
 18294;chiasso
 18295;locarno
 18296;cadenazzo
-18297;locarno nlm
-18298;locarno fart
-18299;bellinzona
 18300;etzwilen
 18301;embrach-rorbas
 18302;andelfingen
 18303;weinfelden
 18304;steckborn
 18305;stein am rhein
-18306;stein urh
-18307;steckborn urh
 18308;flawil
 18309;sulgen
 18310;appenzell
@@ -16377,22 +12884,16 @@
 18314;au sg
 18315;heerbrugg
 18316;teufen
-18317;rheineck schifflände
-18318;au sg monstein
 18319;schwarzenburg
-18320;interlaken west ths
 18321;schönried
 18322;saanenmöser
 18323;lenk im simmental
 18324;wengen wengiboden
-18325;mürren lsms-sbm
 18326;interlaken harderbahn
-18327;mürren lsms-lsms
 18328;goppenstein
 18329;kandersteg
 18330;frutigen
 18331;reichenbach im kandertal
-18332;goppenstein bahnhof
 18333;herzogenbuchsee
 18334;gerlafingen
 18335;huttwil
@@ -16404,19 +12905,10 @@
 18341;giswil
 18342;sachseln
 18343;alpnachstad
-18344;brienz brb
-18345;interlaken ost brs
-18346;brienz brs
 18347;niederrickenbach station
 18348;stansstad
 18349;engelberg
-18350;alpnachstad pb
-18351;flüelen sgv
-18352;stansstad sgv
 18353;küssnacht am rigi sgv
-18354;engelberg bet
-18355;engelberg eb
-18356;alpnachstad sgv
 18357;landquart
 18358;bad ragaz
 18359;grüsch
@@ -16436,185 +12928,18 @@
 18373;zuoz
 18374;zernez
 18375;scuol-tarasp
-18376;scuol psfs
 18377;buchs sg
 18378;flums
 18379;unterterzen
-18380;unterterzen lufag
-18381;zernez staziun
-18382;rougemont bdgag
-18383;zermatt zbag-lz
-18384;zermatt zbag-zsb
-18385;mörel arbag
-18386;fürgangen lfüb
-18387;schönried bdgag-she
-18388;kandersteg (luftseilbahn)
-18389;meiringen luftseilbahn
-18390;engelberg (fürenalp bahn)
-18391;disentis/muster bbd
-18392;bergün/bravuogn sbad
-18393;celerina best-lcs
-18394;pontresina spl
 18395;realp dfb
-18396;meilen autoquai
-18397;unterterzen (see)
-18398;locarno flms
-18399;chateau-d’oex tcpm/tpbm
-18400;schönried bdgag-rls
-18401;rolle gare
-18402;morges gare
-18403;romont fr gare
-18404;aigle gare
-18405;chateau-d’oex gare
-18406;bex gare
-18407;st-maurice vs poste
-18408;le chatelard vs frontiere
-18409;visp bahnhof süd
-18410;gstaad bahnhof
-18411;interlaken west bahnhof
-18412;lauterbrunnen bahnhof
-18413;reichenbach im kandertal
-18414;ins bahnhof
-18415;huttwil bahnhof
-18416;brünig-hasliberg bahnhof
-18417;meiringen bahnhof
-18418;belp bahnhof
-18419;le locle gare
-18420;tramelan gare
-18421;saignelegier gare
-18422;tavannes gare
-18423;laufen (ch) bahnhof
-18424;liestal bahnhof
-18425;oensingen bahnhof
-18426;laufenburg bahnhof
-18427;birr bahnhof
-18428;koblenz bahnhof
-18429;stein-säckingen bahnhof
-18430;giswil bahnhof
-18431;sachseln bahnhof
-18432;stansstad bahnhof
-18433;rotkreuz bahnhof süd
-18434;altdorf ur bahnhof
-18435;göschenen bahnhof
-18436;flüelen bahnhof
-18437;linthal bahnhof
-18438;andermatt bahnhof
-18439;realp post
-18440;thalwil zentrum
-18441;thalwil bahnhof
-18442;affoltern am albis bahnhof
-18443;andelfingen bahnhof
-18444;zürich flughafen bahnhof
-18445;embrach-rorbas bahnhof
-18446;weinfelden bahnhof
-18447;stein am rhein bahnhof
-18448;steckborn bahnhof
-18449;kreuzlingen bahnhof
-18450;sulgen bahnhof
-18451;pfäffikon zh bahnhof
-18452;rafz bahnhof
-18453;birmensdorf zh bahnhof
-18454;ziegelbrücke bahnhof
-18455;glarus bahnhof
-18456;flawil bahnhof
-18457;nesslau-neu st. johann
-18458;buchs sg bahnhof
-18459;teufen ar bahnhof
-18460;teufen ar speicherstrasse
-18461;rheineck bahnhof
-18462;heerbrugg bahnhof
-18463;uznach bahnhof
-18464;lachen sz bahnhof
-18465;grüsch bahnhof
-18466;landquart bahnhof
-18467;sargans bahnhof
-18468;bergün/bravuogn staziun
-18469;flums bahnhof
-18470;davos dorf bahnhof
-18471;scuol-tarasp staziun
-18472;filisur bahnhof
-18473;disentis/muster staziun/posta
-18474;pontresina bahnhof
-18475;samedan bahnhof
+18408;le châtelard-frontière
 18476;tavanasa-breil/brigels staziun
-18477;küblis bahnhof
-18478;tiefencastel bahnhof
-18479;bad ragaz bahnhof
-18480;ilanz bahnhof/post
 18481;biasca
-18482;taverne-torricella
 18483;mendrisio
 18484;airolo
-18485;glattfelden bahnhof
-18486;männedorf bahnhof
-18487;meilen bahnhof
-18488;richterswil bahnhof
-18489;hüntwangen-wil bahnhof
-18490;frutigen bahnhof
-18491;kandersteg bahnhof
-18492;interlaken ost bahnhof
-18493;grindelwald bahnhof
-18494;brienz be bahnhof
-18495;st-imier gare
-18496;herzogenbuchsee bahnhof
-18497;küssnacht am rigi bahnhof
-18498;flüelen hauptplatz
-18499;erstfeld bahnhof
-18500;schwanden gl bahnhof
-18501;cham (ch) bahnhof
-18502;cham (ch) gemeindehaus
-18503;bulle gare
-18504;schwarzenburg bahnhof
-18505;grenchen süd bahnhof
-18506;grenchen nord bahnhof
-18507;sissach bahnhof
-18508;appenzell bahnhof
-18509;au sg gemeindehaus
-18510;ebnat-kappel bahnhof
-18511;locarno
-18512;baden (ch) bahnhof west
-18513;vevey gare
-18514;saanen bahnhof
-18515;schönried bahnhof
-18516;saanenmöser bahnhof
-18517;lenk im simmental bahnhof
 18518;mörel post
-18519;fiesch bahnhof
-18520;fürgangen abzweigung bahnhof
-18521;sierre/siders gare cff
-18522;sierre le bourgeois
-18523;sion gare
-18524;bellinzona piazzale stazione
-18525;mendrisio stazione transito bus
-18526;thusis bahnhof
-18527;brünig-hasliberg waldegg
-18528;samedan post
-18529;cadenazzo
-18530;menziken bahnhof
-18531;meiringen luftseilbahn
-18532;neuhausen (ch) bahnhof sbb
-18533;alpnachstad bahnhof
-18534;sion gare bus sedunois
 18535;st. niklaus (visp)
-18536;chiasso
-18537;le locle jardin klaus
-18538;le locle place du marche
 18539;sedrun tgesa communala
-18540;eglisau bahnhof
-18541;zuoz staziun
-18542;konolfingen bahnhof
-18543;renens vd gare nord
-18544;jestetten bahnhof
-18545;schönenwerd so zentrum
-18546;baden (ch) bahnhof ost
-18547;killwangen bahnhof
-18548;oensingen bahnhof süd
-18549;bulle place de la gare
-18550;aigle novassales
-18551;grenchen postplatz süd
-18552;locarno piazza stazione
-18553;zermatt bahnhof
-18554;sierre hôtel de ville - cff
 18556;dornach-arlesheim
 18557;morges
 18558;leysin-feydey
@@ -16628,7 +12953,6 @@
 18566;kreuzlingen bernrain
 18567;belp
 18568;wengen
-18569;lauterbrunnen blm
 18570;mürren blm
 18571;grindelwald
 18572;disentis/muster
@@ -16648,12 +12972,8 @@
 18586;nove údolí
 18587;praha-bubeneč
 18588;praha-bubny
-18589;praha-smíchov sev.n.
 18590;praha-strašnice zastávka
 18591;praha-zbraslav
-18592;praha nádraží holešovice (m)
-18593;praha smíchovské nádraží (m)
-18594;praha náměstí republiky (m)
 18595;alken st.
 18596;ålsgårde st.
 18597;arden st.
@@ -16891,11 +13211,6 @@
 18831;rovereto
 18832;san candido/innichen
 18834;silandro/schlanders
-18835;tirano
-18836;venezia mestre (viale stazione)
-18837;malles / mals
-18838;venezia tronchetto
-18839;malles / mals
 18840;fortezza/franzensfeste
 18841;ettelbruck
 18842;clervaux
@@ -17135,10 +13450,6 @@
 19084;żary
 19085;krzewina zgorzelecka
 19086;świebodzin
-19087;warszawa zachodnia wkd
-19088;warszawa zachodnia (peron 8)
-19089;katowice dworzec autobusowy piotra skargi 8
-19090;wrocław główny (dworzec autobusowy sucha 1-11)
 19091;świnoujście centrum
 19092;jesenice
 19093;lesce bled
@@ -17182,12 +13493,10 @@
 19132;ascoli satriano
 19133;borgone
 19134;borgoratto
-19135;borgosesia
 19136;anguillara
 19137;antignano
 19138;antrodoco centro
 19139;antrodoco-borgo velino
-19140;anversa-villalago-scanno
 19141;amendola
 19142;amendolara-oriolo
 19143;amorosi melizzano
@@ -17219,7 +13528,6 @@
 19169;allerona-castel viscardo
 19170;alpignano
 19171;altamura
-19172;andora
 19173;altare
 19174;ardore
 19175;arena po
@@ -17303,14 +13611,12 @@
 19254;acerra
 19255;acireale
 19256;acqua acetosa
-19257;alberese
 19258;albinia
 19259;albisola
 19260;albonese
 19261;alcamo diramazione
 19262;alcantara
 19263;cittadella
-19264;catania acquicella
 19265;borgo a buggiano
 19266;borgo a mozzano
 19267;capistrello
@@ -17404,7 +13710,6 @@
 19356;bianze
 19357;colleferro-segni-paliano
 19358;collegno
-19359;collesalvetti
 19360;collevecchio-poggio sommavilla
 19361;colli di monte bove
 19362;colmegna
@@ -17532,7 +13837,6 @@
 19486;perarolo di cadore
 19487;moneglia
 19488;mongardino
-19489;mongrassano-cervicati
 19490;monzuno-vado
 19491;morano sul po
 19492;morcone
@@ -17598,7 +13902,6 @@
 19552;omegna-crusinallo
 19553;occhiobello
 19554;oderzo
-19555;lioni
 19556;licata
 19557;lido di lavinio
 19558;marconi
@@ -17614,7 +13917,6 @@
 19568;francavilla al mare
 19569;desio
 19570;diamante-buonvicino
-19571;diano marina
 19572;felizzano
 19573;feltre
 19574;momo
@@ -17622,7 +13924,6 @@
 19576;molino del pallone
 19577;padiglione
 19578;pergine
-19579;pergola
 19580;peri
 19581;perugia
 19582;pesaro
@@ -17659,7 +13960,6 @@
 19613;dicomano
 19614;oricola-pereto
 19615;monopoli
-19616;monsampolo del tronto
 19617;monselice
 19618;montagnana
 19619;montaguto-panni
@@ -17667,7 +13967,6 @@
 19621;montalto di castro
 19622;monasterace-stilo
 19623;la fiora
-19624;la salle
 19625;militello
 19626;minturno-scauri
 19627;la spezia migliarina
@@ -17754,7 +14053,6 @@
 19709;mortara
 19710;mosciano sant’angelo
 19711;motta di livenza
-19712;morgex
 19713;montemarano
 19714;mombaruzzo
 19715;montemarciano
@@ -17775,7 +14073,6 @@
 19730;prato sesia
 19731;pratola peligna
 19732;pratola peligna superiore
-19733;pre saint didier
 19734;preganziol
 19735;preglia
 19736;premosello-chiovenda
@@ -17842,13 +14139,11 @@
 19799;pontebba
 19800;pontecagnano
 19801;pontecchio marconi
-19802;ponte di brenta
 19803;magliano-crava-morozzo
 19804;montereale valcellina
 19805;monteroduni sant’eusanio
 19806;monteroni d’arbia
 19807;monterosso
-19808;monterosso marche
 19809;monterotondo-mentana
 19810;montesilvano
 19811;monticello d’alba
@@ -17857,10 +14152,8 @@
 19814;lamezia terme centrale
 19815;lamezia terme-nicastro
 19816;omignano-salento
-19817;lamezia terme-sambiase
 19818;mezzano
 19819;praja-ajeta-tortora
-19820;pramaggiore blessaglia
 19821;prasco-cremolino
 19822;potenza superiore
 19823;povo-mesiano
@@ -17958,17 +14251,13 @@
 19919;maddaloni inferiore
 19920;madonna del piano
 19921;madonna del pilone
-19922;falconara
 19923;falconara marittima
 19924;falcone
-19925;falerna
 19926;fanna-cavasso
 19927;fanzolo
-19928;fara
 19929;fornaci di barga
 19930;fornovo
 19931;fosciandora-ceserana
-19932;imperia oneglia
 19933;incisa
 19934;incoronata
 19935;guardavalle
@@ -17992,7 +14281,6 @@
 19953;pietragalla
 19954;pietrasanta
 19955;pietratagliata
-19956;pietrelcina
 19957;pieve ligure
 19958;pignataro maggiore
 19959;pinerolo
@@ -18002,13 +14290,11 @@
 19963;pianoro
 19964;pianzano
 19965;piazza al serchio
-19966;montella
 19967;melfi
 19968;moncalieri
 19969;nogara
 19970;recale
 19971;recco
-19972;redipuglia
 19973;racconigi
 19974;raiano
 19975;empoli
@@ -18020,7 +14306,6 @@
 19982;gavotti
 19983;gela-anic
 19984;gaibanella
-19985;agnone di siracusa
 19986;genova cornigliano
 19987;manoppello
 19988;fabro-ficulle
@@ -18049,7 +14334,6 @@
 20013;golfo aranci
 20014;gonzaga-reggiolo
 20015;gorgo al monticano
-20016;gorizia centrale
 20017;isola della scala
 20018;matrice-montagano-san giovanni in galdo
 20019;mazara del vallo
@@ -18114,7 +14398,6 @@
 20079;fontanafredda
 20080;fontanarosa-cervaro
 20081;fontanetto po
-20082;ghemme
 20083;ghislarengo
 20084;ghivizzano-coreglia
 20085;genova quarto dei mille
@@ -18144,7 +14427,6 @@
 20109;ordona
 20110;pioppe di salvaro
 20111;leonforte-pirato
-20112;pisa aeroporto
 20113;pisa centrale
 20114;pisa san rossore
 20115;piscina di pinerolo
@@ -18165,14 +14447,12 @@
 20130;cutro
 20131;decimomannu
 20132;deiva marina
-20133;mossa
 20134;cupramarittima
 20135;pistoia
 20136;pistoia ovest
 20137;piteccio
 20138;pino-tronzano
 20139;fabriano
-20140;fabriano ca’maiano
 20141;fabrica di roma
 20142;casalbuono
 20143;casale monferrato
@@ -18225,7 +14505,6 @@
 20190;bagnoli-agnano terme
 20191;ceriale
 20192;cesano di roma
-20193;cese
 20194;cesena
 20195;cerea
 20196;ceregnano
@@ -18263,7 +14542,6 @@
 20228;crotone
 20229;caronia
 20230;carbona
-20231;cardillo zen
 20232;bucine
 20233;broni
 20234;budoia-polcenigo
@@ -18275,7 +14553,6 @@
 20240;sant’antimo-sant’arpino
 20241;secugnago
 20242;sedico-bribano
-20243;segesta tempio
 20244;sella di corno
 20245;sellero
 20246;salorno/salurn
@@ -18328,7 +14605,6 @@
 20293;schio
 20294;scicli
 20295;stanghella
-20296;santa maria la longa
 20297;scorcetoli
 20298;scordia
 20299;santa maria maggiore
@@ -18373,7 +14649,6 @@
 20338;san nazario
 20339;san michele di serino
 20340;sant’antonino-vaie
-20341;sarre
 20342;sartirana
 20343;sarzana
 20344;sassano-teggiano
@@ -18388,7 +14663,6 @@
 20353;resana
 20354;resiutta
 20355;rho
-20356;riace
 20357;riardo-pietramelara
 20358;ricadi
 20359;ripafratta
@@ -18418,7 +14692,6 @@
 20384;treviglio ovest
 20385;trivigno
 20386;trofarello
-20387;sanluri stato
 20388;sante marie
 20389;santeramo
 20390;santhia
@@ -18443,7 +14716,6 @@
 20409;valmadonna
 20410;valenza
 20411;valmontone
-20412;valtopina
 20413;vandoies/vintl
 20414;valle di maddaloni
 20415;san giovanni valdarno
@@ -18465,11 +14737,9 @@
 20432;vipiteno/sterzing
 20433;piraineto
 20434;bragno
-20435;varallo sesia
 20436;varano
 20437;varazze
 20438;vigliano d’asti
-20439;vigliano-candelo
 20440;vigna di valle
 20441;vignale
 20442;viterbo porta romana
@@ -18501,7 +14771,6 @@
 20470;sipicciano san nicola
 20471;tito
 20472;tivoli
-20473;tocco-castiglione
 20474;tolentino
 20475;tommaso natale
 20476;tor sapienza
@@ -18550,7 +14819,6 @@
 20519;venezia porto marghera
 20520;venosa-maschito
 20521;villa san giovanni
-20522;villa san giovanni-cannitello
 20523;zoagli
 20524;anconetta
 20525;venzone
@@ -18623,7 +14891,6 @@
 20595;pian del mugnone
 20596;carini torre ciachea
 20597;ancona torrette
-20598;aosta istituto
 20599;vicchio
 20600;vicofertile
 20601;san cassiano
@@ -18657,7 +14924,6 @@
 20629;san lorenzo maggiore
 20630;santa giustina-cesio
 20631;sant’ilario d’enza
-20632;santo stefano udinese
 20633;sgurgola
 20634;sibari
 20635;sicignano degli alburni
@@ -18695,7 +14961,6 @@
 20667;stava/staben
 20668;ciardes/tschars
 20669;vergnasco
-20670;laces/latsch
 20671;lasa/laas
 20672;rablà/rabland
 20673;castelbello/kastelbell
@@ -18768,16 +15033,12 @@
 20740;tre croci
 20741;santo stefano lodigiano
 20742;sezze romano
-20743;genova piazza principe sotterranea
 20744;bronzolo/branzoll
-20745;civitavecchia stazione
 20746;civitella roveto
 20747;san romano-montopoli-santa croce
 20748;sassa-tornimparte
-20749;lagundo/algund
 20750;terzo-montabone
 20751;bagni di lusnizza
-20752;cervo-san bartolomeo
 20753;badesse
 20754;brisighella
 20755;salsomaggiore terme
@@ -18815,7 +15076,6 @@
 20787;saliceto
 20788;teramo
 20789;termini imerese
-20790;terni cospea
 20791;tollo-canosa sannita
 20792;condofuri
 20793;potenza universita
@@ -18823,7 +15083,6 @@
 20795;villa literno
 20796;zappulla
 20797;olgiata
-20798;aosta viale europa
 20799;rovigliano
 20800;serravalle pistoiese
 20801;salbertrand
@@ -18857,7 +15116,6 @@
 20830;altavilla milicia
 20831;anzio colonia
 20832;roma san pietro
-20833;romagnano sesia
 20834;piombino dese
 20835;lecco
 20836;ascea
@@ -18867,7 +15125,6 @@
 20840;fara sabina-montelibretti
 20841;forte dei marmi-seravezza-querceta
 20842;ceprano-falvaterra
-20843;iselle transito
 20844;marmore
 20845;marrubiu-terralba-arborea
 20846;bassano del grappa
@@ -18886,10 +15143,8 @@
 20859;castel bolognese- riolo terme
 20860;dittaino
 20861;pontetto
-20862;fiumefreddo bruzio
 20863;fontaniva
 20864;falciano-mondragone-carinola
-20865;melano-marischio
 20866;napoli campi flegrei
 20867;napoli mergellina
 20868;pellezzano
@@ -18948,7 +15203,6 @@
 20921;nuovo salario
 20922;gagliole
 20923;pizzo
-20924;castelletto ticino
 20925;biella san paolo
 20927;ponte a moriano
 20928;gallese-bassanello
@@ -19010,7 +15264,6 @@
 20986;ruderi di sibilla
 20987;sant’elena-este
 20988;ansedonia
-20989;anulù
 20990;archi
 20991;asciano-monte oliveto maggiore
 20992;asola
@@ -19031,7 +15284,6 @@
 21007;alife
 21008;ancona marittima
 21009;andrano castiglione
-21010;anela
 21011;bosco redole
 21012;arcore
 21013;ardara
@@ -19048,11 +15300,9 @@
 21024;como nord lago
 21025;bisuschio-viggiù
 21026;bitetto-palo del colle
-21027;boccia al mauro
 21028;bollate centro
 21029;canzo
 21030;candoglia-ornavasso
-21031;canelli
 21032;barasso-comerio
 21033;barbaresco
 21034;barbusi
@@ -19069,34 +15319,27 @@
 21045;castellina in chianti-monteriggioni
 21046;bibbiano
 21047;colico
-21048;bologna san vitale
 21049;bologna via larga
-21050;bolognina
 21051;bolotana
 21052;bomba
 21053;arosio
 21054;artogne-gianico
 21055;ardenza
-21056;biella-chiavazza
 21057;binetto
 21058;catanzaro città
 21059;catanzaro pratica
 21060;cattolica-san giovanni-gabicce
-21061;causo
 21062;cava carbonara
 21063;san martino-cava
 21064;castellucchio
-21065;castelluccio
 21066;castelluccio siculo
 21067;castell’alfero
-21068;castiglione di sicilia
 21069;castiglione in teverina
 21070;cisternino città
 21071;citerna taro
 21072;cislago
 21073;capece
 21074;cavarzere centro
-21075;arzachena
 21076;cavorà
 21077;cavriago
 21078;cazzago san martino
@@ -19110,15 +15353,10 @@
 21086;alberobello
 21087;albizzate-solbiate arno
 21088;albuzzano
-21089;alcamo
-21090;abas/ales
 21091;cavagnolo-brusasco
 21092;castronno
-21093;castronovo di sicilia
 21094;birori
 21095;colledimezzo
-21096;borgo
-21097;capitello
 21098;capo di ponte
 21099;celle ligure
 21100;celsita
@@ -19135,12 +15373,10 @@
 21111;chiuro
 21112;cannara
 21113;camaro
-21114;cambiano
 21115;camigliatello silano
 21116;cammarata-san giovanni gemini
 21117;ceglie messapico
 21118;cittanova
-21119;città della pieve
 21120;castelfranci
 21121;castelfranco emilia
 21122;cocconato
@@ -19153,11 +15389,9 @@
 21129;butera
 21130;buttafava
 21131;cabiate
-21132;cignoni
 21133;cimano
 21134;cannole
 21135;castelnuovo belbo
-21136;castelnuovo del friuli
 21137;castelplanio-cupramontana
 21138;castelspina-portanova
 21139;castelvetere
@@ -19173,8 +15407,6 @@
 21149;coratini
 21150;cixerri
 21151;cles
-21152;bellarosa
-21153;bibbona-casale
 21154;bibiana
 21155;campolongo maggiore
 21156;campomaggiore-pietrapertosa
@@ -19189,7 +15421,6 @@
 21165;calciano
 21166;corconio ameno
 21167;corigliano d’otranto
-21168;cormano-brusuglio
 21169;candia lomellina
 21170;como nord borghi
 21171;cantu
@@ -19198,7 +15429,6 @@
 21174;bevera
 21175;bianzone
 21176;castrofilippo
-21177;collevalenza-rosceto-rosarno
 21178;cologne
 21179;cassano d’adda
 21180;cassano spinola
@@ -19209,8 +15439,6 @@
 21185;cosseria
 21186;costa
 21187;costa masnaga
-21188;costigliole d’asti
-21189;costigliole saluzzo
 21190;costigliole (motta di)
 21191;cotilia
 21192;cozze
@@ -19228,12 +15456,9 @@
 21204;abano
 21205;abbadia lariana
 21206;abbiategrasso
-21207;albanella
 21208;cadorago
 21209;buronzo
-21210;cagliari marittima
 21211;cagliari monserrato
-21212;cagliari pirri
 21213;bollate traversagna
 21214;campo di giove
 21215;campo di giove monte maiella
@@ -19241,7 +15466,6 @@
 21217;campagnalupia-camponogara
 21218;campagna-serre-persano
 21219;alessano-corsano
-21220;cinquefrondi
 21221;cesi
 21222;ceto-cerveno
 21223;chambave
@@ -19254,7 +15478,6 @@
 21230;castellazzo-casalcermelli
 21231;castelleone
 21232;albano sant’alessandro
-21233;altavilla
 21234;campomela
 21235;bellavista
 21236;belvi-aritzo
@@ -19268,14 +15491,10 @@
 21244;basentello
 21245;castellina marittima
 21246;ambivere-mapello
-21247;aquino-castrocielo-pontecorvo
 21248;acquaviva delle fonti
 21249;chiusano-cossombrato
 21250;cicala
-21251;bassano romano
 21252;bastia
-21253;bastia mondovì
-21254;bastia rucce
 21255;bauladu-milis
 21256;milano affori
 21257;milano bruzzano
@@ -19286,47 +15505,34 @@
 21262;casole-trenta
 21263;casoli
 21264;garbagnate milanese
-21265;garessio
 21266;garlasco
 21267;dirillo
 21268;dogato
 21269;pontelongo fermata
 21270;pizzighettone-ponte d’adda
 21271;monteoliveto
-21272;patti marina
 21273;pavia porta garibaldi
 21274;pedace
 21275;pedace serrapedace
 21276;pederobba-cavaso-possagno
 21277;pegognaga
 21278;pellegrini
-21279;pellicciari
 21280;penango
-21281;mondovì breo
 21282;monguelfo-casies welsberg-gsies
 21283;morbegno
 21284;morciano-barbarano-giuliano
 21285;morengo-bariano
 21286;mores-ittireddu
 21287;moretta
-21288;montiglio-murisengo
 21289;montirone
 21290;montjovet
-21291;montoro superiore
 21292;pettoranello
 21293;chatillon-saint vincent
-21294;cherasco
-21295;chiasso
 21296;donori
-21297;ferrara porta reno
 21298;fulgatore
 21299;osini-ulassai
 21300;osnago
-21301;osoppo
-21302;ospedaletti ligure
 21303;rivalta scrivia
-21304;rive
-21305;olbia marittima-isola bianca
 21306;olcenengo
 21307;olcio
 21308;olgiate-calco-brivio
@@ -19359,16 +15565,11 @@
 21335;olivetta san michele
 21336;milano porta genova
 21337;libertinia
-21338;limone confine
-21339;lioni-valle delle viti
 21340;bari parco sud
 21341;lido di classe-lido di savio
 21342;lierna
 21343;reggio di calabria marittima
 21344;montecalvo-buonalbergo-casalbore
-21345;fossalta di portogruaro
-21346;francavilla angitola-filadelfia
-21347;francavilla di sicilia
 21348;dorio
 21349;dormelletto
 21350;dormelletto paese
@@ -19378,7 +15579,6 @@
 21354;mollaro
 21355;perfugas
 21356;pertengo
-21357;pertosa
 21358;perugia ponte san giovanni
 21359;perugia sant’anna
 21360;pescariello
@@ -19387,8 +15587,6 @@
 21363;passignano sul trasimeno
 21364;passirano
 21365;paternopoli
-21366;paterno-san pelino
-21367;ormea
 21368;orroli
 21369;oppido lucano
 21370;orbetello-monte argentario
@@ -19399,11 +15597,7 @@
 21375;pallerone
 21376;rizziconi
 21377;feroleto antico-pianopoli
-21378;ferrandina a.l.
 21379;ferrandina scalo matera
-21380;ferrara aleotti
-21381;ronchi dei legionari sud
-21382;san paolo
 21383;milo
 21384;mimiani-san cataldo
 21385;mineo
@@ -19422,29 +15616,23 @@
 21398;lagnasco
 21399;lecco maggianico
 21400;isili
-21401;isola capo rizzuto
 21402;mellitto
 21403;melzo
 21404;menfi
 21405;novate milanese
-21406;ottaviano
-21408;ovada nord
 21409;oviglio
 21410;rovato città
 21411;seriate
 21412;portovecchio di piombino
 21413;isola d’arbia
 21414;monastero-pratavecchia
-21415;lucera citta
 21416;monte melino
 21417;leonessa
 21418;lercara bassa
-21419;lesina
 21420;lesmo
 21421;montecastrilli
 21422;montechiaro d’asti
 21423;monteiasi-montemesola
-21424;ozieri
 21425;ortuabis
 21426;maleo
 21427;malè
@@ -19461,12 +15649,10 @@
 21438;paduli sul calore
 21439;ospedaletto lodigiano
 21440;ospitaletto-travagliato
-21441;palau marina
 21442;margarita
 21443;mariano comense
 21444;morra de sanctis-teora
 21445;motta camastra
-21446;motta sant’anastasia
 21447;motteggiana
 21448;prato sardo
 21449;montemiletto
@@ -19486,7 +15672,6 @@
 21463;provaglio-timoline
 21464;provesano
 21465;quadri
-21466;monchiero-dogliani
 21467;palazzolo dello stella
 21468;palazzolo milanese
 21469;pettorano sul gizio
@@ -19512,7 +15697,6 @@
 21489;osilo
 21490;ponte in valtellina
 21491;ponte nelle alpi-polpet
-21492;ponte parrano di nocera umbra
 21493;gairo-taquisara
 21494;galati
 21495;galdo
@@ -19521,12 +15705,10 @@
 21498;olmedo
 21499;lezza-carpesino
 21500;lauriano
-21501;mirandola-ozzano
 21502;moccaro
 21503;moccone
 21504;montenero valcocchiara
 21505;monte arcau
-21506;monte castelli
 21507;marcellina-palombara
 21508;palombina
 21509;panicaglia
@@ -19537,7 +15719,6 @@
 21514;ponte valleceppi
 21515;pontecosi
 21516;maglie
-21517;magna grecia
 21518;magnacavallo
 21519;monteroni sud
 21520;montesano-buonabitacolo
@@ -19551,12 +15732,10 @@
 21529;locate triulzi
 21530;castagnole delle lanze
 21531;castano primo
-21532;castel bagnolo di orte
 21533;parco dei monaci
 21534;gemonio
 21535;genga-san vittore terme
 21536;ferrera lomellina
-21537;figline-cellara
 21538;fildidonna
 21539;locate varesino-carbonate
 21540;locorotondo
@@ -19586,9 +15765,7 @@
 21564;pontelongo
 21565;robbio
 21566;riofreddo
-21567;romagnano-vietri-salvitelle
 21568;migliarino
-21569;migliarino pisano
 21570;frattarolo
 21571;sant’oliva
 21572;moio-alcantara-malvagna
@@ -19605,9 +15782,7 @@
 21584;latisana-lignano-bibione
 21585;lavino
 21586;lavorate
-21587;luogosano-san mango sul calore
 21588;luras
-21589;luserna san giovanni
 21590;luzzara
 21591;macherio-canonica
 21592;macherio-sovico
@@ -19617,8 +15792,6 @@
 21596;curinga
 21597;fanciullata
 21598;pachino
-21599;imperia porto maurizio
-21600;incisa scapaccino
 21601;induno olona
 21602;inverigo
 21603;irsina
@@ -19635,10 +15808,8 @@
 21614;putignano
 21615;maschio
 21616;masi torello
-21617;massa marittima
 21618;massafiscaglia
 21619;muro leccese
-21620;pietragalla a.l.
 21621;pietrapaola
 21622;pietrarsa-san giorgio a cremano
 21623;pieve albignola
@@ -19659,12 +15830,9 @@
 21638;nurallao
 21639;novara nord
 21640;mozia-birgi
-21641;ragusa ibla
 21642;randazzo
-21643;elini-ibono
 21644;matera
 21645;matino
-21646;narzole
 21647;ozieri-fraigas
 21648;nasisi
 21649;galatone città
@@ -19674,26 +15842,21 @@
 21653;genisi
 21654;manduria
 21655;dragoni
-21656;dronero
 21657;dubino
 21659;fiumelatte
 21660;fiumetorto
-21661;firenze cascine
 21662;gamberale
 21663;gallipoli
 21664;gallitello
 21665;galugnano
 21666;gamalero
 21667;genova vesima
-21668;genzano
 21669;gerbini
 21670;gesico-seurgus
 21671;giuncarico
 21672;giurdignano
 21673;gizzeria lido
 21674;glorie
-21675;golfo aranci marittima
-21676;gorizia confine
 21677;guardia-mangano-santa venerina
 21678;meana-sardo
 21679;meda
@@ -19710,7 +15873,6 @@
 21690;illorai
 21691;imera
 21692;rapolano terme
-21693;eranova
 21694;erba
 21695;esterzili
 21696;exilles
@@ -19736,13 +15898,10 @@
 21716;edolo
 21717;egnazia
 21718;acri-bisignano-luzzi
-21719;adami
 21720;adelfia
 21721;acquanegra cremonese
 21722;acquasparta
-21723;gradisca-san martino
 21724;quistello
-21725;fiumicino
 21726;fivizzano-rometta-soliera
 21727;foiano della chiana
 21728;fondente
@@ -19771,7 +15930,6 @@
 21752;poggiardo
 21753;poggibonsi-san gimignano
 21754;morosolo-casciago
-21755;cusano milanino
 21756;darfo-corna
 21757;decollatura
 21758;delia
@@ -19811,12 +15969,10 @@
 21792;avigliano città
 21793;aurisina
 21794;caprioli
-21795;bricherasio
 21796;brindisi di montagna
 21797;bagnasco
 21798;capurso
 21799;caprigliola-albiano
-21800;civitavecchia viale della vittoria
 21801;civitella-badia al pino
 21802;cividale
 21803;cividate malegno
@@ -19829,7 +15985,6 @@
 21810;brianco
 21811;caranzano-sant’andrea
 21812;carentino
-21813;carrù-clavesana
 21814;caronno pertusella
 21815;cernusco-merate
 21816;caraffa-sarrottino
@@ -19839,7 +15994,6 @@
 21820;carmignano
 21821;carnate-usmate
 21822;carpino
-21823;cuneo gesso
 21824;capriati a volturno
 21825;capralba
 21826;crispiano
@@ -19878,7 +16032,6 @@
 21859;sant’antonio
 21860;silanus
 21861;suelli
-21862;sulmona-introdacqua
 21863;sulzano
 21864;senetica di bondeno
 21865;terrasa
@@ -19890,7 +16043,6 @@
 21871;terranova monferrato
 21872;terrarossa-tresana
 21873;scala di giocca
-21874;siena zona industriale
 21875;san paolo di noto
 21876;san vito città
 21877;correzzola
@@ -19908,7 +16060,6 @@
 21889;scalea-santa domenica talao
 21890;scalenghe
 21891;scandiano
-21892;scanzano-belfiore
 21893;schivenoglia
 21894;sciacca
 21895;scigliano-pedivigliano
@@ -19924,7 +16075,6 @@
 21905;san martino in campo-torgiano
 21906;santa maria colle di serra
 21907;staggia senese
-21908;bari sant’andrea
 21909;san massimo
 21910;cavaria-oggiona-ierago
 21911;sant’angelo dei lombardi
@@ -19937,19 +16087,15 @@
 21918;stroncone
 21919;torrile-san polo
 21920;cadola-soccher
-21921;torre vosa
 21922;torremuzza-reitano
-21923;torrenieri-montalcino
 21924;santa maria del molise
 21925;barrali pimentei
 21926;bassano in teverina
 21927;san michele in bosco
 21928;san nicandro garganico
 21929;sassuolo
-21930;sava
 21931;spezzano della sila
 21932;spezzano piccolo
-21933;spilimbergo
 21934;remedello sotto
 21935;renate-veduggio
 21936;restinco
@@ -19980,24 +16126,20 @@
 21961;rodi garganico
 21962;tromello
 21963;ugovizza-valbruna
-21964;san filippo-santa lucia
 21965;sangiustino
 21966;moncalieri sangone
 21967;sannazzaro
 21968;sannicandro di bari
 21969;sansepolcro
 21970;santa croce del lago
-21971;santa croce di trieste
 21972;santa domenica
 21973;santa luce
 21974;santa maria la bruna
 21975;santa severa
 21976;santena-tetti giro
 21977;santo janni
-21978;santo stefano
 21979;santopadre
 21980;santuario incoronata
-21981;sant’anna (reggio di calabria)
 21982;sanzano-occhino
 21983;sarcidano
 21984;saronno
@@ -20024,7 +16166,6 @@
 22005;rio di pusteria
 22006;bosco (cs)
 22007;sangineto
-22008;san giuliano d’arezzo
 22009;san giuliano milanese
 22010;san giorgio della richinvelda
 22011;san giorgio delle pertiche
@@ -20038,13 +16179,10 @@
 22019;vanzone-isolella
 22020;vidalengo
 22021;vigarano pieve
-22022;modane gare
-22023;san giorgio di sassari
 22024;ottava
 22025;varedo
 22026;varenna-esino
 22027;vigevano
-22028;vigliano d’abruzzo
 22029;visano
 22030;viterbo porta fiorentina
 22031;san benedetto del tronto
@@ -20055,7 +16193,6 @@
 22036;torre de’ picenardi
 22037;torre garga
 22038;torre san giorgio
-22039;torino dora
 22040;san pietro in guarano
 22041;terlano-andriano terlan-andrian
 22042;terme vigliatore
@@ -20068,13 +16205,10 @@
 22049;san benedetto sambro-castiglione pepoli
 22050;san secondo
 22051;sanarica
-22052;saluzzo
 22053;salza irpina
-22054;torre pellice
 22055;tobia
 22056;todi ponte rio
 22057;toline
-22058;tombolo
 22059;tonco-alfiano
 22060;tinnura
 22061;vello
@@ -20086,11 +16220,9 @@
 22067;acquedolci-san fratello
 22068;san gavino
 22069;san giacomo
-22070;san giacomo di spoleto
 22071;san giacomo di teglio
 22072;sant’eufemia d’aspromonte
 22073;villa castelli
-22074;villa cordopatri
 22075;zambana
 22076;roncafort
 22077;orsa
@@ -20100,7 +16232,6 @@
 22081;venegono inferiore
 22082;venegono superiore-castiglione
 22083;villa di tirano
-22084;villa opicina
 22085;villa ortensia
 22086;zeme
 22087;zinasco nuovo
@@ -20124,12 +16255,10 @@
 22105;rovito
 22106;serrastretta carlopoli
 22107;serravalle d’asti
-22110;ventimiglia confine
 22111;villa pitignano
 22112;villa raverio
 22113;villa sant’angelo
 22114;zollino
-22115;venezia asseggiano
 22116;colle val d’elsa
 22117;milano repubblica
 22118;milano dateo
@@ -20138,9 +16267,7 @@
 22121;villa santa maria
 22122;villabassa-braies niederdorf-prags
 22123;firenze porta a prato
-22124;venetico
 22125;milano porta vittoria
-22126;paratico sarnico
 22127;saronno sud
 22128;lido di turbigo
 22129;ferno
@@ -20162,20 +16289,16 @@
 22145;sadali-seulo
 22146;saint marcel
 22147;sairano
-22148;trieste campo marzio loco
 22149;dimaro
 22150;fornaci
-22151;villa opicina confine (sežana)
 22152;zerbinate
 22153;villabella
 22154;villacidro
-22155;villafranca piemonte
 22157;bari
 22158;benevento
 22159;bologna
 22160;catania
 22161;civitavecchia
-22162;asti boana
 22163;solfagnano-parlesca
 22164;sologno
 22165;sondrio
@@ -20186,18 +16309,15 @@
 22170;sindia
 22171;sinopoli-san procopio
 22172;san giorgio morgeto
-22173;san giovanni
 22174;san giovanni in croce
 22175;san giorgio casale
 22176;san giovanni in fiore
 22177;taureana
-22178;versciaco vierschach
 22179;villalvernia
 22180;villafranca tirrena-saponara
 22181;villamaggiore
 22182;villamar
 22184;napoli
-22185;reviglione di somma vesuviana
 22186;palermo
 22187;pisa
 22188;segrate
@@ -20220,7 +16340,6 @@
 22205;serre di rapolano
 22206;veggia
 22207;seveso
-22208;villeneuve
 22209;villetta-malagnino
 22210;trecella
 22211;triflisco
@@ -20237,16 +16356,13 @@
 22222;tresenda-aprica-teglio
 22223;roccabernarda
 22224;soveria mannelli
-22225;ancona piazza cavour
 22226;sorgono
 22227;sorso
 22228;san leonardo di cutro
-22229;san giuseppe vesuviano
 22230;sant’ilario dello jonio
 22231;sant’ilario sangro
 22232;san stefano belbo
 22233;san stefano di camastra-mistretta
-22234;san stefano-riva ligure
 22235;sferro
 22236;settime-cinaglio-mombarone
 22237;rutigliano
@@ -20265,9 +16381,6 @@
 22250;casalecchio garibaldi palasport
 22251;zola centro
 22252;via lunga
-22253;santa teresa longarini
-22254;santo tommaso del piano
-22255;san sebastiano po
 22256;san sostene
 22257;sannicola
 22258;bazzano (emilia-romagna)
@@ -20280,8 +16393,6 @@
 22265;savignano comune
 22266;spondinga-prato spondinig-prad
 22267;sluderno-glorenza schluderns-glurns
-22268;malles venosta mals
-22269;torino madonna di campagna
 22270;rigola-stadio
 22271;venaria
 22272;borgaro torinese
@@ -20323,8 +16434,6 @@
 22309;fano
 22310;forno d’allione
 22311;giovi
-22312;aggius
-22313;dattilo-napola
 22314;delebio
 22315;dervio
 22316;gerenzano-turate
@@ -20344,7 +16453,6 @@
 22330;grondola-guinadi
 22331;erbanno-angone
 22332;melissano
-22333;airole
 22334;redipiano
 22335;miglionico
 22336;palo del colle
@@ -20358,15 +16466,10 @@
 22344;muffa
 22345;san maurizio canavese
 22346;mathi
-22347;cona f.c.
 22348;carpanzano
-22349;san marco
 22350;roma aurelia
 22351;seminara
-22352;brindisi marittima
-22353;civitavecchia marittima
 22354;civita castellana-magliano
-22355;san nicola varco di eboli
 22356;cesano maderno
 22357;san martino
 22358;carisio
@@ -20374,7 +16477,6 @@
 22360;sorrento porto
 22361;tortolì
 22362;casarano
-22363;capodacqua-pieve fanonica
 22364;tradate
 22365;napoli molo beverello
 22366;rescaldina
@@ -20383,7 +16485,6 @@
 22369;casello 11
 22370;salice-veglie
 22371;roccamurata
-22372;troia-castelluccio sauri
 22373;sanluri
 22374;valduggia
 22375;soliera modenese
@@ -20392,7 +16493,6 @@
 22378;serralunga-cereseto
 22379;torre del lauro
 22380;san rocco mantovano
-22381;burgos-esporlatu
 22382;buonfornello
 22383;salve-ruggiano
 22384;san lorenzo / st. lorenzen
@@ -20406,7 +16506,6 @@
 22392;baggiovara
 22393;soleto
 22394;sala al barro-galbiate
-22395;ischia porto
 22396;santa margherita di calabria
 22397;spongano
 22398;villagrande
@@ -20421,19 +16520,14 @@
 22408;fiorentina di piombino
 22409;favarotta
 22410;laives leifers
-22411;casal velino
 22412;campi salentino
 22413;benevento porta rufina
 22414;migliaro
 22415;moiana
 22416;poppi
 22417;porrena-strada-montemignaio
-22418;arbatax
 22419;asigliano vercellese
-22420;bari parco nord
 22421;belgioioso
-22422;maddaloni superiore
-22423;boscoreale
 22424;ateleta
 22425;martis
 22426;arpaia airola-sant’agata dei goti
@@ -20441,7 +16535,6 @@
 22428;barumini
 22429;aprigliano
 22430;massa martana
-22431;marigliano
 22432;pinarolo po
 22433;piana del signore
 22434;masserano
@@ -20465,13 +16558,11 @@
 22452;mede
 22453;petina
 22454;donna
-22455;furbara
 22456;guidonia-montecelio-sant’angelo
 22457;erchie-torre santa susanna
 22458;rapone-ruvo-san fele
 22459;eccellente
 22460;rio marina
-22461;rivisondoli-pescocostanzo
 22462;lugo
 22463;monte san savino
 22464;ospitaletto mantovano
@@ -20479,7 +16570,6 @@
 22466;oniferi
 22467;niella
 22468;gragnano
-22469;fontanamela
 22470;desulo-tonara
 22471;felegara-sant’andrea bagni
 22472;molinella
@@ -20490,23 +16580,18 @@
 22477;mezzolombardo
 22478;melpignano
 22479;oggiono
-22480;derby
 22481;colorno
 22482;comitini-zolfare
 22483;boario terme
 22484;boion
 22485;barbianello
 22486;quincinetto
-22487;isola d’asti
 22488;orio litta
-22489;lej
 22490;montefredane
 22491;ozzano monferrato
 22492;mangone
-22493;portoferraio
 22494;mostizzolo
 22495;motta san damiano
-22496;gattinara
 22497;paderno dugnano
 22498;putignano monte laureto
 22499;marcellinara
@@ -20514,9 +16599,7 @@
 22501;gabella grande
 22502;biassono-lesmo
 22503;arcisate
-22504;arzana
 22505;galatina
-22506;lanusei
 22507;pantiere di castelbellino
 22508;papiano-castello delle forme
 22509;ponte san marco-calcinato
@@ -20544,7 +16627,6 @@
 22531;verzuolo
 22532;villafranca-cantarana
 22533;rimini
-22534;villanovatulo
 22536;fiorano
 22537;villanova d’ardenghi
 22538;san cassiano valchiavenna
@@ -20572,7 +16654,6 @@
 22560;subbiano
 22561;terzolas
 22562;valeriano
-22563;carbonia stato
 22564;san benedetto po
 22565;san nicola arcella
 22566;san martino valle caudina-montesarchio-pannarano
@@ -20584,8 +16665,6 @@
 22572;villasanta
 22573;sant’angelo in formis
 22574;stazione per l’alpago
-22575;santa maria di catanzaro
-22576;toscano
 22577;germagnano
 22578;mezzenile
 22579;pisa san rossore t.
@@ -20593,9 +16672,6 @@
 22581;settimo san pietro
 22582;reggio emilia av mediopadana
 22583;école-valentin
-22584;paris gare du nord eurostar
-22585;marne-la-vallée—chessy eurostar
-22586;lille europe eurostar
 22587;kołobrzeg
 22598;montpellier
 22600;nîmes
@@ -20606,32 +16682,14 @@
 22606;minversheim rue principale
 22607;kastrup lufthavn st.
 22608;zürich hardbrücke
-22609;wien westbahnhof (u6)
-22610;karlsruhe hbf südausgang
-22611;düsseldorf hbf zob
-22612;nürnberg zob
-22613;antwerpen centraal (perron 7 koningin astridplein)
-22614;zürich hb (carpark sihlquai)
-22615;eindhoven stationsweg
-22616;luxembourg gare centrale (quai 13)
-22617;frankfurt (m) hbf stuttgarter straße
-22618;trier hbf (bussteig 1)
-22619;chemnitz bahnhofstr
-22620;kiel hbf kaiserstraße
-22621;bad rappenau busbf r
-22622;neckarsulm bahnhof west
 22623;hahn flughafen terminal 2
-22624;ljubljana avtobusna postaja
-22625;zagreb autobusni kolodvor
 22626;budapest-kelenföld
 22627;klatovy
 22628;břeclav
 22629;domažlice
 22630;cheb
-22631;taizé
 22632;taizé communauté
 22633;taizé mairie
-22634;auterive abri rn-20 (haute garonne)
 22635;châteaubriant tram-train
 22636;issé
 22637;abbaretz
@@ -20642,401 +16700,18 @@
 22642;babinière
 22643;haluchère batignolles
 22644;wien hbf
-22645;gare fictive 1
-22646;gare fictive 2
-22647;gare fictive 3
-22648;gare fictive 4
-22649;gare fictive 5
-22650;gare fictive 6
-22651;gare fictive 1 ce
 22654;london victoria coach station
 22655;sainte-ménéhould médiathèque
-22656;hamburg hbf
-22657;hamburg hbf
-22658;hamburg altona
-22659;hamburg altona
-22660;bielefeld hbf
-22661;bielefeld hbf
-22662;essen hbf
-22663;essen hbf
-22664;hagen hbf
-22665;hagen hbf
-22666;koblenz hbf
-22667;koblenz hbf
-22668;stuttgart hbf
-22669;stuttgart hbf
-22670;hannover hbf
-22671;torino porta susa
-22672;torino porta susa
-22673;ashford international
-22674;ebbsfleet international
-22675;tübingen hbf
 22676;zaragoza delicias
-22677;reutlingen hbf
-22678;lübeck hbf
-22679;oldenburg (oldb)
-22680;passau hbf
-22681;hof hbf
-22682;aschaffenburg hbf
-22683;marburg (lahn)
-22684;paderborn hbf
-22685;singen (hohentwiel)
-22686;enschede
-22687;neuenburg (baden)
-22688;celle
-22689;bremen hbf
-22690;warszawa-centralna
-22691;basel badischer bahnhof
-22692;göttingen
-22693;pforzheim hbf
-22694;ingolstadt hbf
-22695;hildesheim hbf
-22696;bayreuth hbf
-22697;kufstein
-22698;gelsenkirchen hbf
-22699;northeim (han)
-22700;lippstadt
-22701;rheine
-22702;bocholt
-22703;mülheim (ruhr) hbf
-22704;wesel
-22705;bregenz
-22706;aalen
-22707;neustadt (weinstr) hbf
-22708;worms hbf
-22709;leer (ostfriesl)
-22710;goslar
-22711;schweinfurt hbf
-22712;memmingen
-22713;schwerte (ruhr)
-22714;euskirchen
-22715;minden (westf)
-22716;emden hbf
-22717;friedberg (hess)
-22718;unna
-22719;göppingen
-22720;freilassing
-22721;frankfurt (oder)
-22722;eschwege
-22723;fürth (bay) hbf
-22724;hameln
-22725;solingen hbf
-22726;andernach
-22727;betzdorf (sieg)
-22728;neuwied
-22729;itzehoe
-22730;kostrzyn
-22731;budapest
-22732;dobova
-22733;jesenice
-22734;neumünster
-22735;rendsburg
-22736;flensburg
-22737;bad schwartau
-22738;hamburg-altona
-22739;augsburg hbf
-22740;hamburg
-22741;helgoland
-22742;berlin-rummelsburg
-22743;berlin-schöneweide
-22744;hannover-nordstadt
-22745;cottbus
-22746;ahnatal-weimar
-22747;malsfeld
-22748;bebra
-22749;bad hersfeld
-22750;hainewalde
-22751;zwota-zechenbach
-22752;zwota
-22753;stenn
-22754;voigtsgrün
-22755;irfersgrün
-22756;rodewisch
-22757;treuen
-22758;weischlitz
-22759;pirk
-22760;hundsgrün
-22761;bad elster
-22762;sohl
-22763;raun
-22764;bad brambach
-22765;barthmühle
-22766;hamburg
-22767;hosena
-22768;erkrath-nord
-22769;düsseldorf-reisholz
-22770;wuppertal hbf
-22771;heroldsberg nord
-22772;düsseldorf-bilk
-22773;wuppertal-langerfeld
-22774;seddin
-22775;st egidien
-22776;heidenau
-22777;mosel
-22778;nossen
-22779;wittenberge
-22780;seifhennersdorf
-22781;wilhermsdorf mitte
-22782;dortmund hbf
-22783;essen-altenessen
-22784;emmerich
-22785;duisburg hbf
-22786;duisburg hbf
-22787;dortmund hbf
-22788;soest
-22789;bochum-langendreer
-22790;frankfurt-höchst
-22791;mainz-gustavsburg
-22792;wetzlar
-22793;dillenburg
-22794;helmstedt
-22795;peine
-22796;düsseldorf-rath
-22797;uelzen
-22798;mannheim hbf
-22799;karlsruhe-hagsfeld
-22800;weil am rhein
-22801;waldshut
-22802;kaldenkirchen
-22803;düren
-22804;leipzig hbf
-22805;troisdorf
-22806;mechterstädt
-22807;bretleben
-22808;rentzschmühle
-22809;lübeck flughafen
-22810;mannheim hbf
-22811;hinterweidenthal ost
-22812;rosenheim
-22813;waldkraiburg
-22814;münchen-pasing
-22815;münchen hbf
-22816;münchen hbf
-22817;ingolstadt nord
-22818;münchen hbf
-22819;münchen hbf
-22820;münchen ost
-22821;reckenfeld
-22822;wilhelmshaven hbf
-22823;asselheim
-22824;grünstadt nord
-22825;würzburg hbf
-22826;würzburg hbf
-22827;coburg
-22828;magdeburg-rothensee
-22829;schönebeck-frohse
-22830;berlin ostkreuz
-22831;igel
-22832;emmelshausen
-22833;ehr
-22834;schirnding
-22835;regensburg hbf
-22836;wittenberge
-22837;berlin-stresow
-22838;prenzlau
-22839;sassnitz
-22840;sindelfingen
-22841;calw
-22842;weingarten berg
-22843;berlin attilastraße
-22844;zirndorf kneippallee
-22845;neidenfels
-22846;boppard süd
-22847;hamburg-allermöhe
-22848;chemnitz-borna hp
-22849;liederbach
-22850;kelkheim-münster
-22851;bad st. peter-ording
-22852;felde
-22853;garding
-22854;harblek
-22855;katharinenheerd
-22856;kating
-22857;sandwehle
-22858;tating
-22859;tönning
-22860;witzwort
-22861;dagebüll mole
-22862;neidenstein
-22863;waibstadt
-22864;eschelbronn
-22865;aglasterhausen
-22866;lenggries
-22867;tegernsee
-22868;potsdam-babelsberg
-22869;cottbus
-22870;trossingen stadt
-22871;pirna
-22872;mulsum-essel
-22873;gera ost
-22874;wünschendorf
-22875;wünschendorf nord
-22876;zwickau zentrum
-22877;greiz
-22878;greiz-dölau
-22879;elsterberg
-22880;gera-liebschwitz
-22881;nidderau
-22882;dreieich-weibelfeld
-22883;metzingen-neuhausen
-22884;herrenberg zwerchweg
-22885;berlin
-22886;zierenberg-rosental
-22887;walsrode
-22888;peine
-22889;singen industriegebiet
-22890;ulm-donautal
-22891;dormagen
-22892;pulheim
-22893;berlin hbf
-22894;greiz
-22895;offenbach-waldhof
-22896;eiswoog
-22897;altenstadt-höchst
-22898;wolfsgefärth
-22899;selm
-22900;lübeck st. jürgen
-22901;cottbus-sandow
-22902;speyer nord-west
-22903;mosbach west
-22904;julbach
-22905;mügeln bf
-22906;ahlbeck grenze
-22907;ahlbeck ostseetherme
-22908;heringsdorf neuhof
-22909;stubbenfelde
-22910;völklingen
-22911;vilseck
-22912;greifswald
-22913;filderstadt
-22914;dettingen-mitte
-22915;bibelöd
-22916;eschwege-niederhone
-22917;salzburg hbf
-22918;parma
-22919;deventer
-22920;gouda goverwelle
-22921;glanerbrug
-22922;vevey
-22924;bazancourt
-22925;ettendorf
-22926;chatenois
-22927;sentheim
-22928;lauw
-22929;lauw
-22930;masevaux
-22931;sickert
-22932;niederbruck
-22933;kirchberg
-22934;kirchberg
-22935;wegscheid
-22936;oberbruck
-22937;dolleren
-22938;sewen
-22939;sewen
-22940;hattmatt
-22941;steinbourg
-22942;monswiller
-22943;monswiller
-22944;saverne
-22945;saverne
-22946;saverne
-22947;saverne
-22948;bouxwiller
-22949;menchhoffen
-22950;wimmenau
-22951;frohmuhl
-22952;lichtenberg
-22953;lichtenberg
-22954;wimmenau
-22955;rouffach
-22956;illfurth
-22957;brumath
-22958;wilwisheim
-22959;pfaffenhoffen
-22960;adamswiller
-22961;gambsheim
-22962;gambsheim
-22963;hoerdt
-22964;hoerdt
-22965;kurtzenhouse
-22966;kurtzenhouse
-22967;bischwiller
-22968;oderen
-22969;fellering
-22970;moosch
-22971;ingolsheim
-22972;mutzig
-22973;gresswiller
-22974;wisches
-22975;saulxures
-22976;saales
-22977;eguelshardt
-22978;neubourg
-22979;buswiller
-22980;london
 22981;carpentras
 22982;entraigues-sur-la-sorgue
 22983;monteux
-22984;strasbourg gare bd m
-22985;heidelberg hbf w-br
-22986;limburg süd (ice-bhf)
-22987;limburg an der lahn zob süd
-22988;bruxelles-nord (rue du progrès)
-22989;romanshorn autoquai
-22990;bad reichenhall hbf
-22991;bad reichenhall tiroler tor
-22992;feldkirch
-22993;leipzig hbf ostseite bussteig 5
-22994;bad friedrichshall-j
-22995;erfurt hbf ic-hotel
-22996;wien westbf (neubaug)
-22997;wien hbf (tief str)
-22998;weinheim luisenstraße
-22999;passau hbf
-23000;pocking
-23001;riegel-malterdingen ne
-23002;wien handelskai (1-2)
-23003;wien handelskai (u6)
-23004;howald
 23005;praha masarykovo n.
-23006;bülach
-23007;berlin südkreuz bus
 23008;københavn ingerslevsgade
-23009;rostock seehaf fähre
-23010;chojnice
-23011;krzyż
 23012;opole główne
-23013;wien matzleinsdorfer platz
-23014;wien matzleinsdorfer platz t
-23015;frankfurt (oder)
-23016;frankfurt (oder)
-23017;berlin friedrichstr
 23018;auch hôpital
 23019;flughafen wien
 23020;la barasse
-23021;bari policlinico
-23022;torino di sangro-paglieta
-23023;villabate-ficarazzelli
-23024;torino smistamento nord
-23025;aulla
-23026;gaggio
-23027;savona marittima
-23028;torino orbassano
-23029;torino san paolo
-23030;venezia scalo marghera
-23031;villa san giovanni marittima
-23032;genova sampierdarena smistamento
-23033;indicatore
-23034;livorno calambrone
-23035;alseno
-23036;bari san giorgio
-23037;margherita di savoia-ofantino
-23039;tannheim (württ) busbahnhof
-23040;tuttlingen busbahnhof
-23041;engen busbahnhof
-23042;leutkirch busbahnhof
-23043;toulouse gironis
 23044;liège
 23045;reggio emilia
 23046;meinerzhagen
@@ -21054,7 +16729,6 @@
 23058;salina porto
 23059;vulcano porto
 23060;lipari porto
-23061;capri porto
 23062;san giuliano d’arezzo
 23063;san iorio
 23064;baggiovara ospedale
@@ -21083,9 +16757,6 @@
 23087;pratovecchio
 23088;lanzago
 23089;san gottardo
-23090;procida porto
-23091;ischia forio
-23092;ischia casamicciola
 23093;quattro ville
 23094;cesano maderno-groane
 23095;ceriano laghetto-groane
@@ -21115,16 +16786,6 @@
 23119;versciaco elmo/vierschach helm
 23120;sorbello
 23121;viernheim bahnhof oeg
-23122;carpi peruzzi autostazione
-23123;châteauroux dt
-23124;châteauroux croix perrine
-23125;châteauroux lycée agricole
-23126;châteauroux lycée blaise pascal
-23127;châteauroux lycée charmilles
-23128;châteauroux lycée pierre et marie curie
-23129;châteauroux lycée giraudoux
-23130;châteauroux médiathèque
-23131;châteauroux préfecture
 23132;l’alpe d’huez
 23133;les deux alpes
 23134;nice pont michel
@@ -21141,7 +16802,6 @@
 23145;sint-martens-bodegem
 23146;buizingen
 23147;tour et taxis
-23148;antwerpen-haven
 23149;noorderkempen
 23150;heide
 23151;nijlen
@@ -21272,8 +16932,6 @@
 23277;tétange
 23278;walferdange
 23279;wecker
-23280;limoges ciel
-23281;luzern sgv
 23282;ascona
 23283;churwalden
 23284;maloja
@@ -21281,7 +16939,6 @@
 23286;sils/segl maria
 23287;valbella
 23288;vitznau
-23289;roosendaal grens
 23290;aalten
 23291;amsterdam muiderpoort
 23292;apeldoorn de maten
@@ -21312,7 +16969,6 @@
 23317;dronrijp
 23318;duiven
 23319;ede centrum
-23320;eijs-wittem
 23321;eygelshoven
 23322;franeker
 23323;gaanderen
@@ -21322,7 +16978,6 @@
 23327;gramsbergen
 23328;grijpskerk
 23329;groningen noord
-23330;gulpen-wijlre
 23331;hardinxveld blauwe zoom
 23332;hardinxveld-giessendam
 23333;harlingen
@@ -21341,15 +16996,12 @@
 23346;ijlst
 23347;kampen zuid
 23348;kerkrade centrum
-23349;kerkrade west
 23350;kesteren
 23351;klarenbeek
 23352;klimmen-ransdaal
 23353;koudum-molkwerum
 23354;kropswolde
 23355;leerdam
-23356;leeuwarden
-23357;leeuwarden achter de hoven
 23358;leeuwarden camminghaburen
 23359;lichtenvoorde-groenlo
 23360;lochem
@@ -21362,7 +17014,6 @@
 23367;mook molenhoek
 23368;nijmegen goffert
 23369;nijmegen heyendaal
-23370;oldenzaal
 23371;opheusden
 23372;reuver
 23373;roodeschool
@@ -21372,12 +17023,10 @@
 23377;sauwerd
 23378;scheemda
 23379;schin op geul
-23380;simpelveld
 23381;sliedrecht
 23382;sliedrecht baanhoek
 23383;sneek
 23384;sneek noord
-23385;spekholzerheide
 23386;stavoren
 23387;stedum
 23388;swalmen
@@ -21386,12 +17035,10 @@
 23391;uithuizen
 23392;uithuizermeeden
 23393;usquert
-23394;utrecht maliebaan
 23395;valkenburg
 23396;varsseveld
 23397;veendam
 23398;veenwouden
-23399;venlo
 23400;venray
 23401;vierlingsbeek
 23403;voerendaal
@@ -21411,219 +17058,26 @@
 23417;zuidbroek
 23418;zuidhorn
 23419;zwaagwesteinde
-23420;absdorf-hippersdorf
-23421;admont
-23422;altomünster-traunsee
-23423;angertal
-23424;ardning
-23425;arnoldstein
-23426;aschbach
-23427;aspang
-23428;aurachkirchen
-23429;ausschlag-zöbern
-23430;bad blumau
-23431;bad gleichenberg
-23432;bad hall
-23433;bad neusiedl-see
-23434;bad radkersburg
-23435;bad vöslau
-23436;bad waltersdorf
-23437;baden bei wien
-23438;bierbaum
-23439;böckstein
-23440;breitenschützing
-23441;breitenstein
-23442;dellach im drautal
-23443;ebensee
-23444;ebensee landungsplatz
-23445;edlitz-grimmenstein
-23446;eggenburg
-23447;enns
-23448;erlach
-23449;fehring
-23450;feldbach
-23451;feldkirchen in kärnten
-23452;felixdorf
-23453;föderlach
-23454;frankenmarkt
-23455;frastanz
-23456;fraünberg an der enns
-23457;freistadt
-23458;friedberg
 23459;friesach
-23460;frohnleiten
-23461;fürstenfeld
-23462;gänserndorf
-23463;gaflenz
-23464;gleisdorf
-23465;gloggnitz
-23466;gnas
-23467;göpfritz
-23468;goisern jodschwefelbad
-23469;grafendorf bei hartberg
-23470;gratwein-gratkorn
-23471;gstatterboden
-23472;gummern
-23473;gunskirchen
-23474;hallwang-elixhausen
-23475;hartberg
-23476;haus
-23477;hieflau
-23478;hilm-kematen
-23479;hochzirl
-23480;hörsching
-23481;hohenau
-23482;hüttau
-23483;innsbruck-hötting
-23484;jennersdorf
-23485;judendf-strassengel
-23486;kainisch
-23487;kalwang
-23488;kapfenberg
-23489;kindberg
-23490;klamm-schottwien
-23491;klaus
-23492;kleblach-lind
-23493;kleinreifling
-23494;knittelfeld
-23495;kolbnitz
-23496;kremsmünster markt
-23497;krieglach
-23498;krummnuszbaum
-23499;langwies
-23500;lassnitzhöhe
-23501;leibnitz
-23502;lend
-23503;leobersdorf
-23504;liesing
-23506;linz wegscheid
-23507;lochau-hörbranz
-23508;ludesch
-23509;mandling
-23510;marchtrenk
-23511;mariazell
-23512;mautern
-23513;messendorf
-23514;micheldorf
-23515;mitterdorf-veitsch
-23516;mitterweiszenbach
-23517;mödling
-23518;möllbrücke-sachsbg
-23519;mühldorf-möllbrücke
 23520;mürzzuschlag
-23521;nenzing
-23522;nettingsdorf
-23523;neumarkt-köstendorf
-23524;öblarn
-23525;ossiach-bodensdorf
-23526;paternion-feistritz
-23527;payerbach-reichenau
-23528;peggau-deutschfeistr
-23529;pernegg
-23530;pinggau-friedberg
-23531;pitten
-23532;pöchlarn
-23533;pöham
-23534;pregarten
-23535;pusarnitz
-23536;redl-zipf
-23537;rohrbach-vorau
-23538;roppen
-23539;rosenau
-23540;rosenbach
-23541;rothenthurn
-23542;salzburg aigen
-23543;sattendorf
-23544;scheiblingkirchen-warth
-23545;schlierbach
-23546;schönwies
-23547;schwanenstadt
-23548;schwarzenau
-23549;sebersdorf
-23550;seebenstein
-23551;semmering
-23552;sigmundsherberg
-23553;silz
-23554;söchau
-23555;spielfeld-strasz
 23556;spital am pyhrn
-23557;spital am semmering
-23558;st. anton im montafon
-23559;stadt rottenmann
-23560;stams
-23561;steeg-gosau
-23562;stein an der enns
-23563;steindorf am ossiachersee
-23564;steinfeld im drautal
-23565;steinhaus
-23566;steyrling
-23567;strasswalchen
-23568;studenzen-fladnitz
-23569;summerau
-23570;tauchen-schaüregg
-23571;ternitz
-23572;timelkam
-23573;traun
-23574;traunkirchen
-23575;treibach-althofen
-23576;trieben
 23577;tulln
-23578;ulmerfeld-hausmening
 23579;unzmarkt
-23580;völs
-23581;waidhofen an der ybbs
-23582;wald am schoberpasz
-23583;wartberg an der krems
-23584;wartberg im mürztal
-23585;weissenbach / st. gallen
-23586;weissenstein-kellerberg
-23587;weyer
 23588;wien mitte
-23589;wien nord
-23590;wien südbahnhof
 23591;wiener neustadt hbf
-23592;wörschach schwefelb
-23593;ybbs an der donau
-23594;zeltweg
-23595;zirl
 23596;erlangen busbahnhof
 23597;busa di vigonza
 23598;orehoved st.
 23599;paris porte maillot
-23600;berlin-schöneweide
-23601;bamberg bahnhof
-23602;hamburg hbf zob
-23603;thayngen busbahnhof
-23604;singen busbahnhof
-23605;hegyeshalom
-23606;wien westbahnhof (schleife süd)
-23607;nürnberg hbf (nelson-mandela-platz/südausgang)
-23608;jena paradies (knebe)
 23609;wien rennweg
-23610;tatabanya
-23611;pforzheim hbf zob
 23612;chomutov
 23613;aime
 23614;aix-en-provence
 23615;moûtiers
 23616;rotterdam
-23617;milano forlanini
-23618;toulouse chaussee
 23619;la cluse ville
 23620;aubin place monteils
-23621;aire-sur-l’adour avenue des pyrénées
-23622;felletin mairie
 23623;verfeil en tartays
-23624;monnaie gendarmerie
-23625;issoudun jardin
-23626;buzançais croissant
-23627;aire-sur-l’adour place de la liberté
-23628;chatillon mail
-23629;loudéac zi sud
-23630;reignac bourg du fau
-23631;pforzheim zob
-23632;karlsruhe hbf südausgang
-23633;montierchaume place couturier
 23634;valencia
 23635;annecy gare routière
 23636;a alberguería-prado
@@ -21670,7 +17124,6 @@
 23677;almadenejos-almaden
 23678;almagro
 23679;almansa
-23680;almargen-cañete la real
 23681;almazora
 23682;almazán
 23683;almenara
@@ -21678,7 +17131,6 @@
 23685;almonaster-cortegana
 23686;almoraima
 23687;almorchon
-23688;almuradiel-viso del marques
 23689;alora
 23690;alpedrete-mataespesa
 23691;altafulla-tamarit
@@ -21687,7 +17139,6 @@
 23694;alzira
 23695;ametzola
 23696;amusco
-23697;andorra-bus
 23698;andújar
 23699;anglesola
 23700;antequera
@@ -21817,7 +17268,6 @@
 23824;canabal
 23825;cancienes
 23826;candanchu-bus
-23827;cangas-bus
 23828;cantillana
 23829;capçanes
 23830;caracenilla
@@ -21852,7 +17302,6 @@
 23859;cañaveral
 23860;cecebre
 23861;cella
-23862;cellers-llimiana
 23863;celorio
 23864;celra
 23865;cenicero san isidro
@@ -21865,7 +17314,6 @@
 23872;cesantes
 23873;cesuras
 23874;cetina
-23875;ceuta-barco
 23876;chápela
 23877;cheste
 23878;chilches
@@ -21905,7 +17353,6 @@
 23912;cunit
 23913;daimiel
 23914;madrid delicias
-23915;denia-bus
 23916;don benito
 23917;dos hermanas
 23918;dosante cidad
@@ -21945,7 +17392,6 @@
 23952;espinosa de henares
 23953;espinosa de los monteros
 23954;espinosa de villagonzalo
-23955;estepona-bus
 23956;estíbaliz-oreitia
 23957;etxarri-aranatz
 23958;fabara
@@ -22033,7 +17479,6 @@
 24040;jabugo-galaroza
 24041;jaca-bus
 24042;jadraque
-24043;javea-bus
 24044;jerez-aeropuerto
 24045;jimena de la frontera
 24046;jimera de libar
@@ -22075,9 +17520,7 @@
 24082;la roda de albacete
 24083;la selva del camp
 24084;la vecilla
-24085;la zaida-sastago
 24086;lalin
-24087;lantueno-santiurde
 24088;larva
 24089;las aletas
 24090;las cabezas de san juan
@@ -22096,7 +17539,6 @@
 24103;les borges blanques
 24104;les borges del camp
 24105;les franqueses-granollers nord
-24106;lezo-errenteria
 24107;librilla
 24108;lieres
 24109;limpias
@@ -22133,14 +17575,12 @@
 24140;lugones
 24141;méndez álvaro
 24142;madrid - atocha cercanías
-24143;madrid-barajas t4
 24144;madrid-nuevos ministerios
 24145;madrid-ramón y cajal
 24146;madrid-recoletos
 24147;magaz
 24148;manuel-l’enova
 24149;manzanos
-24150;marbella-bus
 24151;marcen-poleñino
 24152;marcilla de navarra
 24153;maría de huerva
@@ -22157,7 +17597,6 @@
 24164;medina del campo
 24165;medinaceli
 24166;meirama picardel
-24167;mengibar-artichuela
 24168;mercadillo-villasana
 24169;meres
 24170;mieres-puente
@@ -22182,7 +17621,6 @@
 24189;montijo
 24190;montijo-el molino
 24191;monzón de campos
-24192;monzón-rio cinca
 24193;mora de rubielos
 24194;mora la nova
 24195;morata de jalón
@@ -22190,7 +17628,6 @@
 24197;moriscos
 24198;muriedas
 24199;muriedas-bahía
-24200;muros-bus
 24201;museo del ferrocarril
 24202;nanclares-langraiz
 24203;narros del castillo
@@ -22206,7 +17643,6 @@
 24213;nubledo
 24214;nueva
 24215;nueva montaña
-24216;nules-la vilavella
 24217;nulles-brafim
 24218;o burgo santiago
 24219;o carballiño
@@ -22234,7 +17670,6 @@
 24241;padrón
 24242;padron-barbanza
 24243;palanquinos
-24244;palau-puigcercos
 24245;palma del rio
 24246;pancorbo
 24247;panticosa-bus
@@ -22247,7 +17682,6 @@
 24254;pedrelo-celtigos
 24255;pedrola
 24256;pedrosa
-24257;pedroso
 24258;pendueles
 24259;perbes
 24260;perlio
@@ -22335,7 +17769,6 @@
 24342;roda de mar
 24343;roda monastre
 24344;roiz
-24345;roquetas-bus
 24346;rubielos de mora
 24347;rueda de jalon-lumpiaque
 24348;sabadell centre
@@ -22348,7 +17781,6 @@
 24355;salillas de jalón
 24356;salinas de pisuerga
 24357;salomo
-24358;samper
 24359;san antonio de requena
 24360;san estevo do sil
 24361;san feliz
@@ -22388,7 +17820,6 @@
 24395;santa maría de huerta
 24396;santa maría de la alameda-peguerinos
 24397;santa maría y la peña
-24398;santa pola-bus
 24399;santander
 24400;santander-feve
 24401;santas martas
@@ -22408,7 +17839,6 @@
 24415;sela
 24416;selgua
 24417;serin
-24418;setenil
 24419;sevilla santa justa
 24420;sevilla-virgen del roció
 24421;sierrapando
@@ -22429,8 +17859,6 @@
 24436;tablada
 24437;taboadela
 24438;tafalla
-24439;tánger med-barco
-24440;tánger ville-barco
 24441;tarancon
 24442;tardelcuende
 24443;tardienta
@@ -22466,7 +17894,6 @@
 24473;uharte-arakil
 24474;ujo
 24475;ulldecona-alcanar-la senia
-24476;ungo nava
 24477;unquera
 24478;utebo
 24479;utiel
@@ -22493,13 +17920,11 @@
 24500;vallfogona de balaguer
 24501;valls
 24502;vedra-ribadulla
-24503;veguellina
 24504;vellisca
 24505;venta mina-siete aguas
 24506;veriña
 24507;vicàlvaro
 24508;vidiago
-24509;vielha-bus
 24510;viernoles
 24511;vigo guixar
 24512;vigo urzáiz
@@ -22525,7 +17950,6 @@
 24532;villabona tabladiello
 24533;villacañas
 24534;villada
-24535;villadangos
 24536;villadepalos
 24537;villadoz
 24538;villafranca de los barros
@@ -24847,8 +20271,6 @@
 26855;poreč autobusni kolodvor
 26856;rovinj autobusni kolodvor
 26857;pula autobusni kolodvor
-26858;milano lampugnano
-26859;como san giovanni autobus
 26860;osnabrück
 26861;heinsberg (rheinl)
 26862;wien
@@ -24909,7 +20331,6 @@
 27044;columbrianos
 27045;coma-ruga
 27046;comunion
-27047;congosto
 27048;cortegana
 27049;a coruña
 27050;cox
@@ -24972,7 +20393,6 @@
 27107;jirueque
 27108;l’albi
 27109;l’ampolla
-27110;l’hostalnou
 27111;la almunia
 27112;la borbolla
 27113;la cavada
@@ -25025,7 +20445,6 @@
 27160;miami-platja
 27161;milagro
 27162;moguer
-27163;montejaque
 27164;montgat
 27165;aginaga
 27166;berbes
@@ -25237,7 +20656,6 @@
 27372;velilla del rio carrion
 27373;velilla de ebro
 27374;velilla de la reina
-27375;venta de gutierrez
 27376;ventosilla
 27377;veranes
 27378;verdiago
@@ -25286,7 +20704,6 @@
 27421;grado
 27422;l’espluga calba
 27423;la aparecida
-27424;la arena
 27425;la milla del río
 27426;la pobla de cérvoles
 27427;la vega de almanza
@@ -25710,20 +21127,12 @@
 27845;nakskov st.
 27846;sakskøbing st.
 27847;søllested st.
-27848;venezia piazzale roma
-27849;pazardzhik
 27850;plovdiv
-27851;svilengrad
 27852;burgas
-27853;gorna orjahovica
-27854;karlovo
-27855;dragoman
 27856;dimitrovgrad
-27857;ruse razpredelitelna
 27858;ruse
 27859;sofia
 27860;varna
-27861;minsk-passajirskii
 27862;adamov
 27863;bakov nad jizerou
 27864;bělá pod bezdězem
@@ -26075,402 +21484,55 @@
 28210;larissa
 28211;volos
 28212;thessaloniki
-28213;kozani
-28214;florina
-28215;drama
 28216;alexandroupoli
-28217;patras
+28217;patras (peloponnese)
 28218;athens
-28219;bralos
-28220;idomeni
-28221;inoi
 28222;katerini
 28223;lamia
 28224;ploče
 28225;knin
-28226;sisak
 28227;šibenik
 28228;kotoriba
-28229;opatija-matulji
 28230;pula
 28231;rijeka
 28232;split
 28233;zadar
-28234;mezőtúr
-28235;mezőberény
-28236;lökösháza
-28237;boba
 28238;kecskemét
-28239;kiskunfelegyhaza
-28240;celldömölk
-28241;dombóvár
-28242;komáron
-28243;szombathely
-28244;győr
-28245;pécs
-28246;kiskunhalas
-28247;szentgotthárd
-28248;jákó-nagybajom
-28249;zalaszentiván
-28250;gyékényes
-28251;szerencs
-28252;fonyod
-28253;szob
-28254;alsóbélatelep
-28255;balatonberény
-28256;balatonszentgyörgy
 28257;nagykanizsa
-28258;ukk
-28259;baja
 28260;keszthely
-28261;karcag
-28262;zalaegerszeg
-28263;veszprém
-28264;cegléd
-28265;kiskőrös
-28266;rajka
-28267;biharkeresztes
-28268;békéscsaba
-28269;budapest-zugló
-28270;forró-encs
-28271;füzesabony
-28272;gyoma
-28273;murony
-28274;gyula
-28275;hatvan
-28276;hidasnémeti
-28277;kelebia
-28278;kisvarda
-28279;kistelek
-28280;kiskunmajsa
-28281;kőbánya-kispest
-28282;kunszentmiklós-tass
-28283;mezőkövesd
-28284;nagykőrös
-28285;nyíregyháza
-28286;püspökladány
-28287;salgótarján
-28288;somoskőújfalu
-28289;tokaj
-28290;vámosgyörk
-28291;záhony 4
-28292;turmantas
-28293;vilnius
-28294;kurcums
-28295;karsava
-28296;riga-passajirskaia
-28297;bitola
 28298;skopje
-28299;ski
 28300;as
-28301;vestby
 28302;moss
-28303;rygge
-28304;rade
-28305;fredrikstad
 28306;sarpsborg
-28307;halden
-28308;askim
-28309;mysen
-28310;arnes
-28311;skarnes
-28312;kongsvinger
-28313;grefsen
-28314;hakadal
-28315;stryken
-28316;harestua
-28317;grua
-28318;roa
-28319;lunner
-28320;gran
-28321;jaren
-28322;bleiken
-28323;eina
-28324;raufoss
-28325;gjøvik
-28326;lillestrøm
-28327;jessheim
-28328;eidsvoll
-28329;tangen
-28330;stange
-28331;hamar
-28332;brumunddal
-28333;moelv
-28334;lillehammer
-28335;ringebu
-28336;vinstra
-28337;kvam
-28338;otta
-28339;dovre
-28340;dombas
-28341;lesja
-28342;bjorli
-28343;åndalsnes
-28344;hjerkinn
-28345;kongsvoll
-28346;oppdal
-28347;berkåk
-28348;storen
-28349;heimdal
-28350;leangen
-28351;hommelvik
-28352;hell
-28353;hegra
-28354;gudå
-28355;meraker
-28356;kopperå
-28357;stjordal
-28358;skatval
-28359;asen
-28360;ronglan
-28361;skogn
-28362;levanger
-28363;verdal
-28364;rora
-28365;sparbu
-28366;steinkjer
-28367;jorstad
-28368;snasa
-28369;grong
-28370;harran
-28371;lassemoen
-28372;namsskogan
-28373;majavatn
-28374;svenningdal
-28375;trofors
-28376;mosjøen
-28377;bjerka
-28378;mo i rana
-28379;dunderland
-28380;lønsdal
-28381;røkland
-28382;rognan
-28383;fauske
-28384;bodø
-28385;ilseng
-28386;loten
-28387;elverum
-28388;rudstad
-28389;rena
-28390;steinvik
-28391;opphus
-28392;stai
-28393;koppang
-28394;atna
-28395;hanestad
-28396;bellingmo
-28397;alvdal
-28398;auma
-28399;tynset
-28400;tolga
-28401;os
-28402;røros
-28403;glåmos
-28404;reitan
-28405;haltdalen
-28406;singsås
-28407;sandvika
-28408;asker
-28409;drammen
-28410;mjøndalen
-28411;hokksund
-28412;kongsberg
-28413;nordagutu
-28414;bo
-28415;lunde
-28416;drangedal
-28417;neslandsvatn
-28418;gjerstad
-28419;vegårshei
-28420;nelaug
-28421;vennesla
-28422;kristiansand
-28423;nodeland
-28424;breland
-28425;marnardal
-28426;audnedal
-28427;snartemo
-28428;storekvina
-28429;gyland
-28430;sira
-28431;moi
-28432;egersund
-28433;vigrestad
-28434;narbo
-28435;bryne
-28436;sandnes
-28437;stavanger
-28438;vikersund
-28439;flaten
-28440;froland
-28441;rise
-28442;arendal
-28443;sande
-28444;holmestrand
-28445;skoppum
-28446;tønsberg
-28447;stokke
-28448;sandefjord
-28449;larvik
-28450;porsgrunn
-28451;skien
-28452;honefoss
-28453;flå
-28454;nesbyen
-28455;gol
-28456;al
-28457;geilo
-28458;ustaoset
-28459;haugastøl
-28460;finse
-28461;hallingskeid
-28462;myrdal
-28463;upsete
-28464;mjølfjell
-28465;reimegrend
-28466;urdland
-28467;voss
-28468;dale
-28469;stanghelle
-28470;vaksdal
-28471;trengereid
-28472;arna
-28473;bergen
-28474;vatnahalsen
-28475;berekvam
-28476;håreina
-28477;flam
-28478;ørneberget
-28479;narvik
-28480;rombak
-28481;katterat
-28482;bjørnfjell
-28483;trondheim
-28484;klepp
-28485;notodden
-28486;varhaug
 28487;rzeszów
-28488;czechowice dziedzice
-28489;trzebiatów
 28490;zebrzydowice
-28491;wałbrzych główny
-28492;świnoujście
-28493;aleksandrów kujawski
-28494;biała podlaska
-28495;białogard
-28496;białystok
-28497;bolesławiec
-28498;brzeg
-28499;bytom
-28500;chełm
-28501;chorzów miasto
 28502;ciechocinek
 28503;częstochowa osobowa
-28504;dębica
-28505;duszniki zdrój
 28506;elbląg
-28507;ełk
-28508;głogów
 28509;gliwice
-28510;gorzów wielkopolski
-28511;hel
 28512;iława główna
 28513;jarocin
-28514;jastarnia
-28515;jaworzyna śląska
-28516;jelenia góra
-28517;jurata
-28518;kalisz
-28519;kamieniec ząbkowicki
-28520;karpacz
-28521;katowice
-28522;kędzierzyn koźle
-28523;kępno
 28524;kielce
 28525;kłodzko główne
-28526;koluszki
-28527;koszalin
-28529;krynica
-28530;kudowa zdrój
-28531;kunowice
-28532;kuźnica białostocka
-28533;lądek zdrój
 28534;leszno
-28535;łódź chojny
-28536;łódź fabryczna
-28537;lubań śląski
-28538;lubliniec
 28539;lubin górniczy
-28540;małkinia
-28541;małaszewicze
-28542;malbork
-28543;marciszów
-28544;muszyna
-28545;nowy sącz
-28546;nowa sól
-28547;nysa
-28548;oława
-28549;oleśnica
-28550;olsztyn główny
 28551;ostrowiec świętokrzyski
 28552;oświęcim
-28553;piła główna
 28554;piotrków trybunalski
-28555;poznań starołęka
-28556;połczyn zdrój
-28557;polanica zdrój
-28558;prudnik
-28559;przemyśl główny
 28560;lublin
-28561;racibórz
 28562;radom
-28563;racławice śląskie
-28564;radomsko
 28565;rybnik
-28566;sanok
-28567;szczecin gumieńce
-28568;siedlce
-28569;sieradz
 28570;skarżysko kamienna
-28571;słubice
 28572;słupsk
 28573;sosnowiec główny
-28574;strzelin
-28575;suwałki
-28576;szklarska poręba górna
-28577;tarnowskie góry
-28578;tarnów
 28579;toruń główny
-28580;trzebinia
-28581;turoszów
 28582;ustka
-28583;wałbrzych
-28584;wadowice
-28585;warszawa gdańska
-28586;wałbrzych miasto
-28587;węgliniec
-28588;władysławowo
 28589;włocławek
-28590;wrocław nadodrze
-28591;wysoka kamieńska
 28592;zabrze
-28593;żagań
 28594;zakopane
-28595;zamość
-28596;zawiercie
 28597;zgorzelec
-28598;zielona góra
 28599;albufeira
-28600;alfarelos
-28601;cascais
-28602;elvas
-28603;estoril
-28604;faro
 28605;setúbal
-28606;silves
-28607;sintra
-28608;tomar
-28609;viana do castelo
 28610;arad
 28611;sibiu
 28612;sighișoara
@@ -26478,73 +21540,27 @@
 28614;oradea
 28615;alba iulia
 28616;brașov
-28617;bucurești nord
 28618;cluj napoca
 28619;constanta
 28620;craiova
-28621;coșlariu
-28622;curtici
 28623;deva
-28624;timișoara nord
-28625;kaliningrad
-28626;sankt-peterburg vitebskii
-28627;sankt-peterburg finlyandskiy
-28629;moskva leningradski
-28630;sankt-peterburg
-28631;sankt-peterburg glavnii
-28632;pragersko
-28633;murska sobota
 28634;postojna
-28636;celje
-28637;divaca
-28638;metlika
-28639;sezana
-28640;čierna nad tisou
-28641;galanta
-28642;plavec
-28643;bratislava nove mesto
-28644;bratislava predmestie
-28645;bratislava vinohrady
 28646;žilina
 28647;košice
 28648;liptovsky-mikuláš
 28649;poprad-tatry
-28650;jagodin
-28651;kiev-passajirskii
-28652;kovel
-28653;korosten
-28654;odessa-glavnaia
-28655;rafalovka
-28656;sarny
-28657;zabolote
-28658;ankara
-28659;istanbul
-28660;izmir
-28661;apatin
-28662;beograd dunav
-28663;bor
-28664;crveni krst
-28665;dimitrovgrad-caribrod
-28666;kikinda
-28667;kosovo polje
-28668;knjaževac
-28669;kosovska mitrovica
 28670;zaječar
 28671;leskovac
 28672;kraljevo
 28673;kragujevac
 28674;nikšić
 28675;novi sad
-28676;prahovo pristanište
 28677;priština
 28678;prizren
 28679;ruma
 28680;negotin
-28681;prahovo selo
 28682;sombor
-28683;sremska mitrovica
 28684;uzice
-28685;valjevo
 28686;požega
 28687;prijepolje
 28688;bijelo polje
@@ -26553,244 +21569,15 @@
 28691;bar
 28692;kolašin
 28693;vladičin han
-28694;kuršumlija
-28695;peć
-28696;grobelno
-28697;opatija-matulji
-28698;pula
 28699;banja luka
 28700;bihać
-28701;bos krupa
-28702;bosanski novi
 28703;čapljina
 28704;doboj
-28705;licka kaldrma
-28706;martin brod
-28707;ploče
-28708;podlugovi
-28709;priboj
-28710;prijedor
 28711;tuzla
-28712;zavidovići
 28713;zenica
-28714;bitola
-28715;demir kapija
-28716;negotino vardar
-28717;prilep
-28718;skopje
-28719;kićevo
-28720;veles
 28722;beograd
 28723;kumanovo
 28724;niš
-28725;vyborg
-28726;ähtäri
-28727;ainola
-28728;alavus
-28729;aviapolis
-28730;dragsvik
-28731;eläinpuisto-zoo
-28732;eno
-28733;espoo
-28734;haapajärvi
-28735;haapamäki
-28736;haarajoki
-28737;haksi
-28738;hankasalmi
-28739;hanko asema
-28740;hanko-pohjoinen
-28741;harjavalta
-28742;haukivuori
-28743;heinävesi
-28744;helsinki asema
-28745;herrala
-28746;hiekkaharju
-28747;hikiä
-28748;hinthaara
-28749;humppila
-28750;huopalahti
-28751;hyvinkää
-28752;hämeenlinna
-28753;höljäkkä
-28754;iisalmi
-28755;iittala
-28756;ilmala asema
-28757;imatra asema
-28758;inkeroinen
-28759;inkoo
-28760;isokyrö
-28761;joensuu asema
-28762;jokela
-28763;jorvas
-28764;joutseno
-28765;juupajoki
-28766;jyväskylä
-28767;jämsä
-28768;järvelä
-28769;järvenpää asema
-28770;kajaani
-28771;kannelmäki
-28772;kannus
-28773;karjaa
-28774;karkku
-28775;kauhava
-28776;kauklahti asema
-28777;kauniainen
-28778;kausala
-28779;kemi
-28780;kemijärvi
-28781;kera
-28782;kerava asema
-28783;kerimäki
-28784;kesälahti
-28785;keuruu
-28786;kiiala
-28787;kilo
-28788;kirkkonummi
-28789;kitee
-28790;kiuruvesi
-28791;kivistö
-28792;kohtavaara
-28793;koivuhovi
-28794;koivukylä
-28795;kokemäki
-28796;kokkola
-28797;kolari
-28798;kolho
-28799;kontiomäki
-28800;koria
-28801;korso
-28802;kotka asema
-28803;kotkan satama
-28804;kouvola asema
-28805;kuopio asema
-28806;kupittaa
-28807;kylänlahti
-28808;kymi
-28809;kyminlinna
-28810;käpylä
-28811;lahti
-28812;laihia
-28813;lapinlahti
-28814;lappeenranta
-28815;lappila
-28816;lappohja
-28817;lapua
-28818;leinelä
-28819;lempäälä
-28820;lentoasema
-28821;leppävaara
-28822;lieksa
-28823;lievestuore
-28824;loimaa
-28825;louhela
-28826;luoma
-28827;lusto
-28828;malmi
-28829;malminkartano
-28830;mankki
-28831;martinlaakso
-28832;masala
-28833;mikkeli
-28834;misi
-28835;mommila
-28836;muhos
-28837;muurola
-28838;myllykoski
-28839;myllymäki
-28840;myyrmäki
-28841;mäkkylä
-28842;mäntsälä
-28843;mäntyharju
-28844;nastola
-28845;nikkilä
-28846;nivala
-28847;nokia
-28848;nuppulinna
-28849;nurmes
-28850;oitti
-28851;orivesi
-28852;orivesi keskusta
-28853;oulainen
-28854;oulu asema
-28855;oulunkylä
-28856;paimenportti
-28857;paltamo
-28858;parikkala
-28859;parkano
-28860;parola
-28861;pasila asema
-28862;pasila autojuna-asema
-28863;pello
-28864;petäjävesi
-28865;pieksämäki asema
-28866;pihlajavesi
-28867;pitäjänmäki
-28868;pohjois-haaga
-28869;pori
-28870;porvoo
-28871;puistola
-28872;pukinmäki
-28873;punkaharju
-28874;purola
-28875;pyhäsalmi
-28876;pännäinen
-28877;pääskylahti
-28878;rekola
-28879;retretti
-28880;riihimäki asema
-28881;rovaniemi
-28882;runni
-28883;ruukki
-28884;ryttylä
-28885;salo
-28886;santala
-28887;saunakallio
-28888;savio
-28889;savonlinna asema
-28890;seinäjoki asema
-28891;siilinjärvi asema
-28892;simpele
-28893;siuntio
-28894;skogby
-28895;sukeva
-28896;suonenjoki
-28897;tammisaari
-28898;tampere asema
-28899;tapanila
-28900;tavastila
-28901;tervajoki
-28902;tervola
-28903;tikkurila asema
-28904;toijala
-28905;tolsa
-28906;tornio-itäinen
-28907;tuomarila
-28908;turenki
-28909;turku asema
-28910;turku satama
-28911;tuuri
-28912;uimaharju
-28913;utajärvi
-28914;uusikylä
-28915;vaala
-28916;vaasa
-28917;vainikkala asema
-28918;valimo
-28919;vammala
-28920;vantaankoski
-28921;varkaus
-28922;vehkala
-28923;vihanti
-28924;vihtari
-28925;viiala
-28926;viinijärvi
-28927;villähde
-28928;vilppula
-28929;vuonislahti
-28930;ylistaro
-28931;ylitornio
-28932;ylivieska
 28933;bergamo-orio al serio aeroporto
 28934;lurbe—st-christau
 28935;aigrefeuille–le thou
@@ -26798,19 +21585,6 @@
 28937;utrecht vaartsche rijn
 28938;utrecht
 28939;bourg-en-bresse gare routière
-28940;bourg-en-bresse archives
-28941;privas cours du palais
-28942;st-étienne châteaucreux gare routière
-28943;lyon part-dieu gare routière
-28944;loches saint-jacques
-28945;ussel notre dame
-28946;bitche quartier driant
-28947;le mont dore centre
-28948;schweighouse église protestante
-28949;castres chic hopital
-28950;la courtine gare
-28951;romorantin lycée claude de france
-28952;obernai passage à niveau
 28953;imperia
 28954;ponte di nona
 28955;lamone-cadempino
@@ -26821,16 +21595,9 @@
 28960;madonna di campiglio
 28961;cortina d’ampezzo
 28962;bellach
-28963;lyon perrache gare routière
-28964;romans gare routière
-28965;albigny neuville arrêt tcl
-28966;vienne gare routière
-28967;feyzin arrêt tcl
 28968;bridoré saint-martin
-28969;buzançais sapin vert
 28970;wolfenschiessen
 28971;immensee
-28972;maastricht station bus
 28973;sagliains
 28974;diano
 28975;andora
@@ -26841,7 +21608,6 @@
 28988;malpensa aeroporto
 28989;capriate a4
 28990;lauria-galdo
-28991;brig bahnhofplatz
 28992;bremen
 28993;darmstadt
 28994;magdeburg
@@ -26888,7 +21654,6 @@
 29035;achterwehr
 29036;esens bahnhofstraße
 29037;alfter-impekoven
-29038;aurich zob web
 29039;bad wimpfen im tal
 29040;bad rappenau kurpark
 29041;beringerfeld
@@ -26952,12 +21717,9 @@
 29099;weißenhorn-eschach
 29100;witzighausen
 29101;wullenstetten
-29102;heidenau-großsedlitz pechhütte
-29103;ludwigshafen-oggersheim rhb
 29104;ruschberg
 29105;heimbach (nahe) ort
 29106;baumholder
-29107;leipzig karlsruher str
 29108;langhagen
 29109;blumberg-rehhahn
 29110;burkhardswalde-maxen
@@ -26966,35 +21728,23 @@
 29113;leipzig grünauer allee
 29114;köttewitz
 29115;leipzig bayerischer bahnhof
-29116;leipzig markt
 29117;leipzig mdr
 29118;leipzig nord
-29119;leipzig wilhelm-leuschner-platz
 29120;leipzig-lindenau
 29121;lohsa
 29122;ludwigsfelde-struveshof
 29123;markkleeberg nord
 29124;meißen altstadt
 29125;naumburg-roßbach
-29126;pirna-copitz nord heinrich-heine-str
-29127;pirna-copitz schulstraße
 29128;pulsnitz süd
 29129;reinsdorf (bei nebra)
 29130;schöna dorfplatz
 29131;leipzig allee-center
 29132;zellendorf
 29133;plauen (vogtl) mitte
-29134;chemnitz bernsbachplatz
-29135;chemnitz brückenstraße/freie presse
-29136;heide-büsum flugplatz
 29137;bruchhausen-vilsen
 29138;heiligenberg dev
-29139;norden kof
 29140;heiligenfelde
-29141;pockau-lengefeld zentrale bushaltestelle
-29142;hirschfelde markt
-29143;philippsburg marktplatz
-29144;schirgiswalde post
 29145;bad schallerbach-wallern
 29146;gmünd nö
 29147;raaba
@@ -27007,21 +21757,16 @@
 29154;drösing
 29155;ebenfurth
 29156;eisenstadt
-29157;wien floridsdorf
 29158;frauenkirchen
 29159;gars-thunau
-29160;wien gersthof
 29161;gols
 29162;gries am brenner
 29163;grünau im almtal
 29164;hard-fussach
-29165;wien heiligenstadt
-29166;wien hernals
 29167;hötzelsdorf-geras
 29168;hollabrunn
 29169;horn nö
 29170;korneuburg
-29171;wien krottenbachstraße
 29172;lamprechtshausen
 29173;strass im zillertal
 29174;taufkirchen an der pram
@@ -27030,19 +21775,15 @@
 29177;wallern im burgenland
 29178;weiden am see
 29179;wulkaprodersdorf
-29180;wien matzleinsdorf (autoreisezuganlage)
 29181;trimmelkam
 29182;villach warmbad
 29183;aschau im zillertal
-29184;wien breitensee
 29185;irnfritz
 29186;ried im zillertal
 29187;riedau
-29188;salzburg hbf bahnsteige (11-12)
 29189;müllendorf
 29190;st andrä am zicksee
 29191;neusiedl am see
-29192;wien oberdöbling
 29193;obernberg-altheim
 29194;wien franz-josefs-bahnhof
 29195;pamhagen
@@ -27056,7 +21797,6 @@
 29203;mönchhof-halbturn
 29204;nickelsdorf
 29205;oberndorf bei salzburg bahnhof
-29206;wien ottakring
 29207;parndorf ort
 29208;pürbach-schrems
 29209;jenbach zillertalbahn
@@ -27072,23 +21812,8 @@
 29219;weng bei neumarkt
 29220;flughafen graz-feldkirchen
 29221;sopron
-29222;berlin ostkreuz
-29223;hamburg hbf (kirchenallee)
-29224;leipzig hbf goethestraße
-29225;halle (saale) hbf gl 13a
-29226;roermond stadskantoor/outlet
-29227;maastricht station
-29228;st margrethen sg bahnhof
-29229;chur postautostation
-29230;liège-guillemins (busparkplatz)
 29231;luckau busbahnhof
-29232;berlin hbf (washingtonplatz)
-29233;memmingen bahnhof
 29234;wien hbf (bahnsteige 1-2)
-29235;salzburg hbf (forum)
-29236;innsbruck hbf (verladestelle)
-29237;bahnhof bruchsal
-29238;wien längenfeldgasse
 29239;livorno
 29240;la spezia
 29241;potenza
@@ -27114,18 +21839,7 @@
 29261;bellaria igea marina
 29262;puy de dôme (panoramique des dômes)
 29263;château de chaumont-sur-loire
-29264;acciaroli
-29265;agropoli fermata autobus
-29266;castellabate fermata autobus
 29267;marina di camerota
-29268;policastro fermata autobus
-29269;padula-teggiano fermata autobus
-29270;palinuro fermata autobus
-29271;polla-pertosa fermata autobus
-29272;sapri fermata autobus
-29273;contursi terme fermata autobus
-29274;valbonati-villammare
-29275;paestum fermata autobus
 29276;zoo de beauval
 29277;château de chambord
 29278;porto
@@ -27146,11 +21860,6 @@
 29294;lloret de mar
 29295;bratislava
 29296;braunschweig
-29297;aéroport paris roissy charles de gaulle cdg t2 a-c
-29298;aéroport paris roissy charles de gaulle cdg t2 b-d
-29299;aéroport paris roissy charles de gaulle cdg t2 e-f
-29300;aéroport paris roissy charles de gaulle cdg t1
-29301;paris étoile - champs élysées
 29302;st. peter-molinis
 29303;třinec centrum
 29304;bystřice
@@ -27172,8 +21881,6 @@
 29320;lviv
 29321;mukacheve
 29322;uzhhorod
-29323;wrocław
-29324;rabka-zdrój
 29325;kraków
 29326;chorzów
 29327;bonn un campus
@@ -27187,7 +21894,6 @@
 29335;wien praterstern
 29336;wien quartier belvedere
 29337;agrigento
-29338;bolzano/bozen
 29339;messina
 29340;cerignola
 29341;lamezia terme
@@ -27278,8 +21984,6 @@
 29426;wolpertshausen
 29427;wustrow
 29428;zingst
-29429;wien mitte-landstraße
-29430;wien flughafen (cat)
 29431;bapaume
 29432;basel euroairport
 29433;cheverny
@@ -27325,7 +22029,6 @@
 29474;vigo di fassa
 29475;ziano
 29476;dover
-29477;milton keynes
 29478;miskolc
 29479;oslo
 29480;splügen
@@ -30031,10 +24734,8 @@
 32181;xinzo
 32182;xunqueira de ambía
 32183;yuncos
-32184;udine stazione (viale europa unita)
-32185;villach hbf (busbahnhof)
 32186;ortisei
-32187;selva di val gardena
+32187;sëlva di val gardena
 32188;santa cristina val gardena
 32189;albergaria-a-velha
 32190;amarante
@@ -30178,21 +24879,21 @@
 32329;novi pazar
 32330;sliven
 32331;stara zagora
-32332;bellcaire d`empordà
-32333;esterri d`àneu
-32334;l`alguenya
-32335;l`avellà
-32336;l`escala
-32337;les cases d`alcanar
-32338;l`espunyola
-32339;l`hostal
+32332;bellcaire d’empordà
+32333;esterri d’àneu
+32334;l’alguenya
+32335;l’avellà
+32336;l’escala
+32337;les cases d’alcanar
+32338;l’espunyola
+32339;l’hostal
 32340;montserrat parc
-32341;pla de l`ermita
-32342;s`agaró
-32343;santa cristina d`aro
-32344;valència d`àneu
-32345;vallbona d`anoia
-32346;vilanova de l`aguda
+32341;pla de l’ermita
+32342;s’agaró
+32343;santa cristina d’aro
+32344;valència d’àneu
+32345;vallbona d’anoia
+32346;vilanova de l’aguda
 32347;bjelovar
 32348;hum na sutli
 32349;našice
@@ -30424,12 +25125,12 @@
 32575;conthey
 32576;brazatortas
 32577;burguillos
-32578;castellnou d`oluges
-32579;castelló d`empúries
-32580;l`alcúdia de crespins
-32581;l`ametlla de montsec
-32582;la seu d`urgell
-32583;monestir d`avellanes
+32578;castellnou d’oluges
+32579;castelló d’empúries
+32580;l’alcúdia de crespins
+32581;l’ametlla de montsec
+32582;la seu d’urgell
+32583;monestir d’avellanes
 32584;petrer
 32585;santa ana
 32586;santa olalla
@@ -30467,9 +25168,6 @@
 32618;vila cova de lixa
 32619;călan
 32620;moscow
-32621;wasserburg busbahnhof (bodensee)
-32622;friedrichshafen busbahnhof
-33296;eindhoven jfk
 33297;banzi
 33298;napoli capodichino aeroporto
 33299;montenero di bisaccia
@@ -30514,9 +25212,8 @@
 33338;velykyi bychkiv
 33339;funchal
 33340;eindhoven airport
-33341;lisbon airport
+33341;aeroporto de lisboa humberto delgado
 33342;bologna airport
-33343;palermo aeroporto (fermata autobus)
 33344;rothrist
 33345;porto airport
 33346;funchal madeira airport
@@ -31471,10 +26168,8 @@
 34296;aéroport de nice
 34297;københavn lufthavn
 34298;bari largo ciaia
-34299;taranto piazza fontana
 34300;bari largo sorrentino
 34301;bari viale unità d‘italia
-34302;taranto porto mercantile
 34303;gioia del colle ospedale
 34304;hallstatt bahnhof
 34305;muckendorf-wipfing bahnhof
@@ -31966,7 +26661,6 @@
 34792;balerna
 34793;cantello-gaggiolo
 34794;bergamo ospedale
-34795;portomaggiore verginese
 34796;chieti madonna delle piane
 34797;nepezzano-piano d’accio
 34798;l’aquila sassa nsi
@@ -31980,10 +26674,6 @@
 34806;brindisi cittadella della ricerca
 34807;firenze the mall
 34808;castiglione cosentino università della calabria
-34809;catanzaro cittadella regionale
-34810;catanzaro università magna grecia
-34811;catanzaro funicolare
-34812;catania aeroporto
 34813;perugia aeroporto
 34814;valletta
 34815;st. paul’s bay
@@ -31996,27 +26686,18 @@
 34822;acaya
 34823;acquarica del capo
 34824;acquarica di lecce
-34825;acquaviva delle fonti (bus)
-34826;adelfia 55 sp133
-34827;alberobello viale margherita
 34828;alberobello coreggia
 34829;alessano
-34830;alezio via mariana albina
 34831;alliste
 34832;andrano
 34833;aradeo
 34834;bagnolo del salento piazza san giorgio
-34835;bari istituto giulio cesare
-34836;bari marconi
-34837;bari poggiofranco
 34838;bari scuole polivalenti
 34839;bari zona industriale (bus)
 34840;bari via napoli caserma
 34841;bari la fitta
-34842;bologna fico
 34843;bologna zanolini
 34844;borgagne
-34845;brindisi ospedale perrino
 34846;brindisi rione casale
 34847;brindisi via palmiro togliatti
 34848;casalini
@@ -32065,7 +26746,6 @@
 34891;depressa
 34892;diso
 34893;erchie sp64
-34894;erchie stazione
 34895;fasano via roma
 34896;fasano villa comunale
 34897;felline
@@ -32075,7 +26755,6 @@
 34901;gagliano del capo
 34902;galatina piazza alighieri
 34903;galatone via savoia
-34904;gallipoli via franco
 34905;gallipoli baia verde
 34906;gallipoli via agrigento
 34907;gallipoli via chiesanuova
@@ -32096,9 +26775,8 @@
 34922;lecce zona industriale
 34923;lecce ecotekne
 34924;lecce palazzetto dello sport
-34925;lecce stazione
 34926;lequile
-34927;leuca
+34927;santa maria di leuca
 34928;lido silvana
 34929;lizzanello
 34930;lizzano
@@ -32114,7 +26792,6 @@
 34940;manduria istituto agrario
 34941;manduria piazza vittorio emanuele
 34942;manduria piazzale sant’antonio
-34943;manduria viale mancini
 34944;manduria piazza vittorio emanuele ii
 34945;marina di lizzano
 34946;marittima
@@ -32127,15 +26804,12 @@
 34953;massafra bivio
 34954;massafra corso roma
 34955;masseria boncore
-34956;matino via iv novembre
 34957;melendugno
-34958;melissano viale stazione
 34959;melpignano via giuseppe verdi
 34960;merine
 34961;mesagne cittadella della ricerca
 34962;mesagne piazza vittorio emanuele ii
 34963;minervino di lecce
-34964;mola di bari piazza della republica
 34965;moncalvo
 34966;monopoli scuole polivalente
 34967;monopoli via vittorio veneto
@@ -32146,7 +26820,6 @@
 34972;morciano
 34973;morigino
 34974;mottola bivio
-34975;bari mungivacca via caduti del lavoro
 34976;bari mungivacca ikea
 34977;muro leccese via corsica
 34978;napoli porto immacolatella
@@ -32222,8 +26895,6 @@
 35048;taranto paolo vi politecnico
 35049;taranto piazza castello
 35050;taranto scesa vasto
-35051;taranto stazione fs
-35052;taranto galese bus
 35053;taranto via alto adige
 35054;taranto via cesare battisti 329
 35055;taranto via federico di palma
@@ -32240,7 +26911,6 @@
 35066;torre lapillo
 35067;torre santa susanna via roma
 35068;torre santo stefano
-35069;tricase viale stazione
 35070;triggianello
 35071;triggiano zona 167
 35072;triggiano via giovanni casalino
@@ -32358,7 +27028,7 @@
 35184;sedlare
 35185;karlino
 35186;gaber
-35187;monte sant`angelo
+35187;monte sant’angelo
 35188;miliva
 35189;rothenburg
 35190;vrtnjakovec
@@ -32438,7 +27108,7 @@
 35264;sandanski
 35265;kryzkalnis
 35266;nesebar
-35267;sant`arcangelo
+35267;sant’arcangelo
 35268;obzor
 35269;marsicovetere
 35270;biarritz airport
@@ -32447,7 +27117,7 @@
 35273;telsiai
 35274;chiaravalle centrale
 35275;quadrivio
-35276;san mango d`aquino
+35276;san mango d’aquino
 35277;podmilačje
 35278;rudanovac
 35279;šiauliai
@@ -32891,7 +27561,7 @@
 35717;san cosmo albanese
 35718;san demetrio corone
 35719;san giorgio albanese
-35720;santa sofia d`epiro
+35720;santa sofia d’epiro
 35721;schiavonea
 35722;st. gangloff
 35723;stegna
@@ -33189,7 +27859,6 @@
 36015;schull
 36016;trélazé
 36017;danjoutin
-36018;belfort-montbéliard tgv (meroux)
 36019;morvillars
 36020;grandvillars
 36021;joncherey
@@ -33197,6 +27866,1833 @@
 36023;zator
 36024;eemshaven
 36025;brno dolní nádraží
-36026;villefranche-sur-saône gare routière
-36027;haguenau moulin neuf
-36028;leipzig hbf (fernbus-terminal)
+36029;ins dorf
+36030;reiden
+36031;unterentfelden oberdorf
+36032;walchwil hörndli
+36033;segnas
+36034;st-blaise-lac
+36035;pilatus kulm
+36036;la chaux-d’abel
+36037;schachen (herisau)
+36038;leuggelbach
+36039;rorschach stadt
+36040;rüti gl
+36041;studen be
+36042;niederweningen dorf
+36043;le stand
+36044;fey
+36045;buchli
+36046;verdasio
+36047;buchs ag
+36048;rümlingen
+36049;meggen
+36050;les echenards
+36051;selzach
+36052;cousset
+36053;wienacht-tobel
+36054;kaufdorf
+36055;turbenthal
+36056;malters
+36057;mezzovico
+36058;mellingen heitersberg
+36059;langenthal industrie nord
+36060;oberwangen
+36061;san nicolao
+36062;ardez
+36063;arbon seemoosriet
+36064;basel st-jakob
+36065;belfaux-village
+36066;les chézards
+36067;colombier
+36068;cottens
+36069;grandvaux
+36070;rank
+36071;hinteregg
+36072;holzhäusern
+36073;lavin
+36074;mols
+36075;mies
+36076;rebstein-marbach
+36077;neuchâtel evole
+36078;ringlikon
+36079;rudolfstetten
+36080;rosé
+36081;solduno
+36082;sur roche
+36083;st-gallen marktplatz
+36084;prilly-malley
+36085;salez-sennwald
+36086;sisikon
+36087;schachen lu
+36088;oberrieden dorf
+36089;willisau
+36090;vaumarcus
+36091;lupfig
+36092;winterthur wülflingen
+36093;zürich stadelhofen fb
+36094;meggen zentrum
+36095;bischofszell nord
+36096;cornaux
+36097;luzern verkehrshaus
+36098;eiken
+36099;illnau
+36100;kölliken oberdorf
+36101;worblaufen
+36102;emmenbrücke gersag
+36103;henggart
+36104;dinhard
+36105;les deurres
+36106;hochdorf schönau
+36107;zollikofen
+36108;busswil
+36109;malleray-bévilard
+36110;knonau
+36111;hendschiken
+36112;dielsdorf
+36113;kemptthal
+36114;buchrain
+36115;clarens
+36116;cheyres
+36117;suhr
+36118;les evouettes
+36119;niederglatt
+36120;grolley
+36121;lutry
+36122;zürich kreuzplatz
+36123;col-de-bretaye
+36124;fayot
+36125;trimbach
+36126;lally
+36127;schwendi bei grindelwald
+36128;bremgarten isenlauf
+36129;zufikon hammergut
+36130;zug oberwil
+36131;yens
+36132;rueras
+36133;steffisburg
+36134;dulliken
+36135;lyssach
+36136;langenthal süd
+36137;wengernalp
+36138;hagneck
+36139;henniez
+36140;kurzrickenbach seepark
+36141;lustmühle
+36142;langenthal gaswerk
+36143;ermatingen
+36144;st-prex
+36145;muolen
+36146;vauderens
+36147;schinznach bad
+36148;gonten
+36149;sattel-aegeri
+36150;steinebrunn
+36151;territet
+36152;les breuleux-eglise
+36153;hurden
+36154;wilen bei wollerau
+36155;grüenfeld
+36156;st-légier-village
+36157;eigergletscher
+36158;sumiswald-grünen
+36159;grubenwald
+36160;niederbipp
+36161;urtenen
+36162;innertkirchen grimseltor
+36163;les geneveys-sur-coffrane
+36164;root d4
+36165;wünnewil
+36166;les nicolets
+36167;bern stöckacker
+36168;zürich waldhaus dolder
+36169;bern brünnen westside
+36170;denges-echandens
+36171;serocca
+36172;rubigen
+36173;wichtrach
+36174;lugano-paradiso
+36175;ringoldingen
+36176;aarwangen vorstadt
+36177;cressier fr
+36178;liebefeld
+36179;kleindietwil
+36180;felsberg
+36181;wollerau
+36182;scharnageln
+36183;aigle-château
+36184;la gottaz
+36185;le boéchet
+36186;gais
+36187;bernina diavolezza
+36188;lüdem
+36189;ruderbach
+36190;hölstein
+36191;ballens
+36192;stoss ar
+36193;bronschhofen amp
+36194;altstätten stadt
+36195;les posses
+36196;morteratsch
+36197;zürich römerhof
+36198;weissenburg
+36199;zürich balgrist
+36200;fontanivent
+36201;echallens
+36202;rigi kulm
+36203;gletsch
+36204;belp steinbach
+36205;collombey-muraz
+36206;sihlau
+36207;waldenburg
+36208;heiden
+36209;bettwiesen
+36210;campascio
+36211;forch
+36212;gammenthal
+36213;schwende
+36214;uetliberg
+36215;erlen
+36216;vuiteboeuf
+36217;steinegg
+36218;les echets
+36219;kölliken
+36220;ballwil
+36221;bergfrieden
+36222;steinmaur
+36223;collombey
+36224;cadera
+36225;luzern allmend/messe
+36226;schottikon
+36227;hirschlang
+36228;deitingen
+36229;tiefenbach dfb
+36230;la barboleuse
+36231;la heutte
+36232;lütisburg
+36233;beinwil am see
+36234;solothurn sternen
+36235;cormoret
+36236;renan be
+36238;grandson
+36239;kesswil
+36240;le châtelard vs
+36241;lüscherz
+36242;freienbach sob
+36243;zürich affoltern
+36244;caslano
+36245;villars-sur-ollon golf
+36246;bouveret
+36247;schlattingen
+36248;siggenthal-würenlingen
+36249;itingen
+36250;epesses
+36251;chénens
+36252;chavornay
+36253;borgnone-cadanza
+36254;blumenau
+36255;sirnach
+36256;fontannaz-seulaz
+36257;münchenstein
+36258;alpnach dorf
+36259;riazzino
+36260;mels
+36261;muttenz
+36262;nieder- und oberurnen
+36263;niederbipp dorf
+36264;kiesen
+36265;wohlen oberdorf
+36266;galmiz
+36267;châteauneuf-conthey
+36268;kaiseraugst
+36269;thörishaus dorf
+36270;biel/bienne bözingenfeld/champs-de-boujean
+36271;neyruz
+36272;sitterdorf
+36273;hallwil
+36274;pratteln salina raurica
+36275;bowil
+36276;mägenwil
+36277;apples
+36278;bodio ti
+36279;bischofszell stadt
+36280;sommerau
+36281;bassersdorf
+36282;leysin-village
+36283;kaltbrunn
+36284;pfungen
+36285;matran
+36286;bad zurzach
+36287;unterzollikofen
+36288;villette vd
+36289;kerzers papiliorama
+36290;glanzenberg
+36291;entlebuch
+36292;stammheim
+36293;châtillens
+36294;chambrelien
+36295;wauwil
+36296;egnach
+36297;hettlingen
+36298;oberbuchsiten
+36299;st-gallen winkeln
+36300;le landeron
+36301;zürich titlisstrasse
+36302;murg
+36303;werthenstein
+36304;zug fridbach
+36305;hünenberg zythus
+36306;saland
+36307;sins
+36308;boll-utzigen
+36309;baar neufeld
+36310;frenkendorf-füllinsdorf
+36311;triboltingen
+36312;domdidier
+36313;boudry littorail
+36314;ebikon
+36315;estavayer-le-lac
+36316;belfaux cff
+36317;bern europaplatz
+36319;rämismühle-zell
+36320;diessenhofen
+36321;ependes
+36322;gisikon-root
+36323;guntershausen
+36324;frinvillier-taubenloch
+36325;fribourg/freiburg poya
+36326;kallnach
+36327;fehraltorf
+36328;münsterlingen spital
+36329;utzenstorf
+36330;dotzigen
+36331;meyrin
+36332;baldegg kloster
+36333;zug casino
+36334;chambésy
+36335;lucens
+36336;morges-st-jean
+36337;genthod-bellevue
+36338;genève-sécheron
+36339;faoug
+36340;wangen an der aare
+36341;diepflingen
+36342;feuerthalen
+36343;hüttlingen-mettendorf
+36344;winterthur töss
+36345;lausen
+36346;st-katharinental
+36347;schänis
+36348;schlatt
+36349;lonay-préverenges
+36350;holderbank ag
+36351;tannay
+36352;oberentfelden
+36353;märstetten
+36354;grellingen
+36355;oberkirch
+36356;eismeer
+36357;duggingen
+36358;oppikon
+36359;alvaneu
+36360;route de morgins
+36361;les hauts-geneveys
+36362;staad
+36363;st-gingolph (suisse)
+36364;biel mett
+36365;steinhausen
+36366;st-léonard
+36367;rüschlikon
+36368;emmat
+36369;villy
+36370;reutlingen
+36371;merlischachen
+36372;burghalden
+36373;generoso vetta
+36374;ostermundigen
+36375;sorvilier
+36376;altendorf
+36377;courtepin
+36378;eclépens
+36379;kollbrunn
+36380;wabern bei bern
+36381;aadorf
+36382;schöftland
+36383;st-légier-gare
+36384;räterschen
+36385;sempach-neuenkirch
+36386;bazenheid
+36387;champ-du-moulin
+36388;steinach
+36389;wolhusen weid
+36390;sur-le-buis
+36391;bevaix
+36392;thalheim-altikon
+36393;neuenhof
+36394;cappella-agnuzzo
+36395;benzenschwil
+36396;corcelles-nord
+36397;güttingen
+36398;suberg-grossaffoltern
+36399;lalden
+36400;wasserauen
+36401;corcelles be
+36402;bitsch
+36403;fideris
+36404;valmont
+36405;gfeld
+36406;jegenstorf
+36407;croy-romainmôtier
+36408;gränichen
+36409;hasle lu
+36410;bever
+36411;vernand-camarès
+36412;bäretswil
+36413;le pied-d’or
+36414;büren an der aare
+36415;wald
+36416;affoltern-weier
+36417;fontanney
+36418;st-gallen haggen
+36419;mörigen
+36420;küsnacht goldbach
+36421;lindenholz
+36422;seftigen
+36423;vuarennes
+36424;wiedlisbach
+36425;la perche
+36426;aarwangen schloss
+36427;rigi staffel
+36428;bretonnières
+36429;st-urban ziegelei
+36430;les bovets
+36431;au zh
+36432;krummenau
+36433;langwies zh
+36434;les sciernes
+36435;montreux-collège
+36436;hünenberg chämleten
+36437;château-de-blonay
+36438;arveyes
+36439;la sagne
+36440;bronschhofen
+36441;ipsach herdi
+36442;langnau-gattikon
+36443;tschamut-selva
+36444;blitzingen
+36445;langwiesen
+36446;le manège
+36447;distelberg
+36448;häusernmoos
+36449;les neys
+36450;les salines
+36451;wartensee
+36452;les emibois
+36453;palagnedra
+36454;genève-stade
+36455;winterthur hegi
+36456;urnäsch
+36457;gränichen töndler
+36458;reppischhof
+36459;lattrigen
+36460;zweibrücken
+36461;kaltenherberg
+36462;aigle-parc aventure
+36463;bätterkinden
+36464;gryon-chalméry
+36465;cinuos-chel-brail
+36466;thurnen
+36467;chamby-musée
+36468;le tremblex
+36469;reverolle
+36470;büren zum hof
+36471;bern bümpliz nord
+36472;intragna
+36473;ballens-froideville
+36474;wängi
+36475;cazis
+36476;fayaux
+36477;ulrichen
+36478;neumühle
+36479;zimeysa
+36480;bern felsenau
+36481;waltikon
+36482;st-urban
+36483;boudry
+36484;couvet
+36485;warmesberg
+36486;schwendi bei heiden
+36487;niederried
+36488;grandval
+36489;schafhausen
+36490;etiez
+36491;la cibourg
+36492;aigle-hôpital
+36493;mendrisio san martino
+36494;emmenmatt
+36495;fräschels
+36496;egg
+36497;bern weissenbühl
+36498;crémines-zoo
+36499;zürich manegg
+36500;basel bad bf
+36501;ligerz
+36502;rümikon ag
+36503;zweidlen
+36504;dagmersellen
+36505;zäziwil
+36506;roggwil-wynau
+36507;corseaux-cornalles
+36508;bauma
+36509;lengnau
+36510;yverdon-champ pittet
+36511;schwerzenbach zh
+36512;moreillon
+36513;vufflens-la-ville
+36514;uerikon
+36515;egerkingen
+36516;mauraz
+36517;cugy fr
+36518;villaz-st-pierre
+36519;mittlerschwanden
+36520;gübsensee
+36521;st-erhard-knutwil
+36522;le marais
+36523;winteregg
+36524;gryon bois-gentil
+36525;jona
+36526;bubendorf bad
+36527;valeyres-sous-montagny
+36528;vufflens-le-château
+36529;le pont
+36530;näfels-mollis
+36531;waldstatt
+36532;waldburg
+36533;les ponts-de-martel
+36534;granges-marnand
+36535;gerolfingen
+36536;zell
+36537;bühler
+36538;oey-diemtigen
+36539;monthey-hôpital
+36540;moudon
+36541;st-saphorin
+36542;zürich seebach
+36543;mumpf
+36544;zürich leimbach
+36545;solothurn allmend
+36546;matzingen
+36547;rheinfelden augarten
+36548;sugnens
+36549;brienzwiler
+36550;lützelflüh-goldbach
+36551;les ripes
+36552;la chaux-de-fonds-grenier
+36553;nänikon-greifensee
+36554;pontenet
+36555;dachsen
+36556;areuse les isles littorail
+36557;bolligen
+36558;hochdorf
+36559;kempraten
+36560;hindelbank
+36561;dietikon stoffelbach
+36562;corcapolo
+36563;ittigen bei bern
+36564;biberegg
+36565;davos glaris
+36566;ossingen
+36567;essert-sous-champvent
+36568;netstal
+36569;berlingen
+36570;chamby
+36571;cham alpenblick
+36572;läufelfingen
+36573;vögelinsegg
+36574;im holz
+36575;trubschachen
+36576;assens
+36577;döttingen
+36578;bargen
+36579;emmenbrücke
+36580;sonvilier
+36581;bürglen
+36582;allmend
+36583;oberburg
+36584;bière
+36585;gerra (gambarogno)
+36586;villars-bozon
+36587;mannenbach-salenstein
+36588;betten talstation
+36589;berg
+36590;zürich tiefenbrunnen
+36591;eggerberg
+36592;rupperswil
+36593;pampigny-sévery
+36594;nottwil
+36595;niederweningen
+36596;zürich dolder
+36597;romiti felsentor
+36598;rietheim
+36599;bendlehn
+36600;siebnen-wangen
+36601;bei den weihern
+36602;lancy-pont-rouge
+36603;schloss laufen am rheinfall
+36604;scheuren
+36605;steinen
+36606;cheseaux
+36607;uetendorf allmend
+36608;olten hammer
+36609;russin
+36610;dietfurt
+36611;muri ag
+36612;klingnau
+36613;schmitten
+36614;brittnau-wikon
+36615;arnegg
+36616;la chaux-des-breuleux
+36617;tegna
+36618;tecknau
+36619;le noirmont
+36620;zürich wetlistrasse
+36621;oberdorf bl winkelweg
+36622;l’isle
+36623;wiesengrund
+36624;vuadens-sud
+36625;oeschseite
+36626;blankenburg
+36627;oberdiessbach
+36628;sentier-orient
+36629;riedmatt sz
+36630;trogen
+36631;sternen bei teufen
+36632;furka dfb
+36633;rietli
+36634;paccot
+36635;bremgarten west
+36636;castione-arbedo
+36637;ponte tresa
+36638;martigny-croix
+36639;rothenburg dorf
+36640;zürich selnau
+36641;otelfingen golfpark
+36642;litzirüti
+36643;ringgenberg
+36644;samstagern
+36645;schönbühl sbb
+36646;wimmis
+36647;rosshäusern
+36648;weberei matzingen
+36649;mettmenstetten
+36650;les breuleux
+36651;zürich triemli
+36652;neuhausen rheinfall
+36653;burglauenen
+36654;maiacher
+36655;planchamp
+36656;schwarzwasserbrücke
+36657;les bois
+36658;jakobsbad
+36659;reinach ag nord
+36660;saas
+36661;lommiswil
+36662;sumvitg-cumpadials
+36663;zürich schweighof
+36664;dallenwil
+36665;zollbrück
+36666;worbboden
+36667;st-stephan
+36668;rigi wölfertschen-first
+36669;zumikon
+36670;oberentfelden engelplatz
+36671;locarno san antonio
+36672;neuenegg
+36673;schwarzer bären
+36674;rodels-realta
+36675;wengwald
+36676;en charnet
+36677;la tine
+36678;mülenen
+36679;tuilerie
+36680;sammelplatz
+36681;givisiez
+36682;st-cergue les cheseaux
+36683;union-prilly
+36684;la chaudanne-les moulins
+36685;klosters selfranga
+36686;grésaley
+36687;court
+36688;tramelan-dessous
+36689;neuchâtel port-de-serrières
+36690;surava
+36691;schöftland nordweg
+36692;vaulruz-sud
+36693;lütschental
+36694;muttbach-belvédère
+36695;biglen
+36696;glion
+36697;toveyre
+36698;bovernier
+36699;gasel
+36700;kirchberg-alchenflüh
+36701;fischenthal
+36702;kempten
+36703;toffen
+36704;st-gallen birnbäumen
+36705;les coeudres-est
+36706;zürich hegibachplatz
+36707;san antonino
+36708;cery-fleur-de-lys
+36709;petit-martel
+36710;klosters dorf
+36711;zürich binz
+36712;st-gallen ab
+36713;san nazzaro
+36714;nidau
+36715;grafenort
+36716;münchwilen tg
+36717;riffelalp
+36718;reichenburg
+36719;sarnen nord
+36720;schüpfen
+36721;prélionne
+36722;villars-sur-glâne
+36723;otelfingen
+36724;bôle
+36725;uttwil
+36726;signau
+36727;steinhausen rigiblick
+36728;basel dreispitz
+36729;kradolf
+36730;luchsingen-hätzingen
+36731;creux-de-genthod
+36732;zürich wiedikon
+36733;seon
+36734;pully-nord
+36735;magliaso paese
+36736;la tour-de-peilz
+36737;worb sbb
+36738;mühlau
+36739;niederhasli
+36740;villeret
+36741;camedo
+36742;avenches
+36743;foyer dents-du-midi
+36744;steinerberg
+36745;kreuzlingen hafen
+36746;freienbach sbb
+36747;tägertschi
+36748;oberrieden
+36749;walterswil-striegel
+36750;agno
+36751;köniz
+36752;feldbrunnen
+36753;la verrerie
+36754;oberried am brienzersee
+36755;versoix
+36756;tägerwilen dorf
+36757;solothurn baseltor
+36758;eschenbach
+36759;escholzmatt
+36760;la plaine
+36761;urdorf weihermatt
+36762;mosen
+36763;lavorgo
+36764;papiermühle
+36765;räfis-burgerau
+36766;luterbach-attisholz
+36767;rikon
+36768;zug chollermüli
+36769;aarburg-oftringen
+36770;weissbad
+36771;altnau
+36772;winkel am zürichsee
+36773;müllheim-wigoltingen
+36774;la conversion
+36775;mammern
+36776;tann-dürnten
+36777;bilten
+36778;ambrì-piotta
+36779;rohrbach
+36780;murgenthal
+36781;s-chanf
+36782;le creux-des-biches
+36783;furna
+36784;bütschwil
+36785;hauptwil
+36786;yverdon william barbey
+36787;les chevalleyres
+36788;landschlacht
+36789;st-blaise cff
+36790;zürchersmühle
+36791;cressier ne
+36792;zürich wipkingen
+36793;rüthi sg
+36794;noiraigue
+36795;gorgier-st-aubin
+36796;mellikon
+36797;hägendorf
+36798;ermensee
+36799;pully
+36800;rümlang
+36801;oberaach
+36802;st-gallen bruggen
+36803;hitzkirch
+36804;corgémont
+36805;dompierre
+36806;concise
+36807;linthal braunwaldbahn
+36808;vouvry
+36809;rickenbach-attikon
+36810;hedingen
+36811;aarberg
+36812;baar lindenpark
+36813;essert-pittet
+36814;gibswil
+36815;reuchenette-péry
+36816;kalpetran
+36817;brügg be
+36818;etoy
+36819;rivaz
+36820;koblenz dorf
+36821;zug postplatz
+36822;zürich stadelhofen
+36823;les tuileries
+36824;niederwangen
+36825;oberriet
+36826;speicher
+36827;oberkulm post
+36828;sembrancher
+36829;schalunen
+36830;obermuhen
+36831;bannwil
+36832;vionnaz
+36833;ranzo-san abbondio
+36834;schöfflisdorf-oberweningen
+36835;aesch
+36836;rabius-surrein
+36837;mussachen
+36838;palézieux-village
+36839;bern bümpliz süd
+36840;deisswil
+36841;oberrüti
+36842;gontenschwil
+36843;roggwil buchägerten
+36844;zug schutzengel
+36845;eigerwand
+36846;münchenwiler-courgevaux
+36847;biberist ost
+36848;boudry tuilière
+36849;crêt-d’y-bau
+36850;oberalppass
+36851;eyholz
+36852;waldibrücke
+36853;marin-epagnier
+36854;buttes
+36855;brüttelen
+36856;biel (goms)
+36857;zwingen
+36858;goldau a4
+36859;château-d’hauteville
+36860;chemex
+36861;broc-village
+36862;bussigny
+36863;chexbres-village
+36864;le bémont
+36865;mittelmuhen
+36866;hauteville
+36867;teufenthal ag
+36868;riffelberg
+36869;st-gallen notkersegg
+36870;burgdorf buchmatt
+36871;roches grises
+36872;rigi staffelhöhe
+36873;cully
+36874;neuchâtel serrières ruau
+36875;zürich giesshübel
+36876;davos wolfgang
+36877;exergillod
+36878;alter zoll
+36879;vechigen
+36880;zetzwil
+36881;rossinière
+36882;davos monstein
+36883;tobel-affeltrangen
+36884;aareschlucht ost mib
+36885;ollon
+36886;gänsbrunnen
+36887;château-d’oex la palaz
+36888;dieni
+36889;ponte brolla
+36890;zizers
+36891;oberkulm
+36892;roggwil dorf
+36893;biberist rbs
+36894;bigenthal
+36895;hebrig
+36896;la tour-de-trême parqueterie
+36897;la ferrière
+36898;zufikon belvédère
+36899;la large-journée
+36900;davos frauenkirch
+36901;findelbach
+36902;fiesch-feriendorf
+36903;celerina staz
+36904;leysin-grand-hôtel
+36905;märwil
+36906;zürich brunau
+36907;madulain
+36908;lüen-castiel
+36909;boden
+36910;grengiols
+36911;neukirch-egnach
+36912;unterentfelden post
+36913;gutenburg
+36914;rueun
+36915;punt muragl
+36916;niederdorf
+36917;les fontanelles
+36918;les granges (orbe)
+36919;broc-fabrique
+36920;brusio
+36921;haut-de-caux
+36922;bleien liebegg
+36923;pied du barrage
+36924;s-chanf marathon
+36925;orbe
+36926;verchiez
+36927;davos laret
+36928;albeuve
+36929;lessoc
+36930;bubendorf
+36931;rudolfstetten hofacker
+36932;zürich saalsporthalle
+36933;berikon-widen
+36934;ospizio bernina
+36935;brienzer rothorn
+36936;chardonney-château
+36937;petit-martel-est
+36938;jouxtens-mézery
+36939;burgdorf steinhof
+36940;roggwil schmitten
+36941;reinach ag mitte
+36942;uitikon waldegg
+36943;stofel
+36944;grindelwald grund
+36945;neuchâtel place pury littorail
+36946;kaiserstuhl ow
+36947;corbier
+36948;versmont
+36949;plambuit
+36950;wittenbach
+36951;hölstein süd
+36952;martigny-expo
+36953;crémines
+36954;widen heinrüti
+36955;ebligen
+36956;menznau
+36957;muhen nord
+36958;montricher
+36959;untervaz-trimmis
+36960;st-éloi
+36961;le day
+36962;romanel-sur-lausanne
+36963;la médettaz
+36964;glion-collège
+36965;bäch
+36966;häggenschwil-winden
+36967;prélaz-sur-blonay
+36968;la brinaz
+36969;planalp
+36970;st-triphon-village
+36971;bel-air leb
+36972;lausanne-chauderon
+36973;bellavista
+36974;tusinge
+36975;waltensburg/vuorz
+36976;heimberg
+36977;riedbach
+36978;fruttli
+36979;le sépey
+36980;rosental
+36981;hirschberg
+36982;ems werk
+36983;aigle-dépôt
+36984;sendy-sollard
+36985;bioggio
+36986;frauenfeld marktplatz
+36987;niederteufen
+36988;murkart
+36989;nidau beunden
+36990;le séchey
+36991;schwäbis
+36992;rochers-de-naye
+36993;lanzenhäusern
+36994;neirivue
+36995;areuse littorail
+36996;solliat-golisse
+36997;ferenbalm-gurbrü
+36998;cavadürli
+36999;le rocheray
+37000;horw
+37001;le lieu
+37002;walzenhausen
+37003;mogelsberg
+37004;les esserts-de-rive
+37005;la roulaz
+37006;bern tiefenau
+37007;kriens mattenhof
+37008;tramelan-chalet
+37009;aareschlucht west
+37010;obergesteln
+37011;les marches
+37012;langendorf
+37013;champéry-village
+37014;innertkirchen mib
+37015;mitlödi
+37016;alle
+37017;chur wiesental
+37018;schönbühl rbs
+37019;nätschen
+37020;chur west
+37021;bonaduz
+37022;bouquetins
+37023;zollikerberg
+37024;wildpark-höfli
+37025;altmarkt
+37026;val-d’illiez
+37027;pont du rhône
+37028;pieterlen
+37029;thalbrücke
+37030;gränichen oberdorf
+37031;mumpé tujetsch
+37032;tägerschen
+37033;grand-moulin
+37034;müntschemier
+37035;wiler
+37036;sonzier
+37037;six-fontaines
+37038;schönbühl shoppyland
+37039;hölstein weidbächli
+37040;attiswil
+37041;la ruaz
+37042;les combes
+37043;verscio
+37044;remaufens
+37045;adliswil
+37046;la combe
+37047;rigi klösterli
+37048;les planches (aigle)
+37049;les fumeaux
+37050;semsales
+37051;altmatt
+37052;allières
+37053;sood-oberleimbach
+37054;la sagne-eglise
+37055;niederwald
+37056;la corbatière
+37057;zürich friesenberg
+37058;zihlbrücke
+37059;st-gallen schülerhaus
+37060;la presta mines d’asphalte
+37061;la cour
+37062;kehlhof
+37063;magliaso
+37064;oberdorf so
+37065;blausee-mitholz
+37066;preda
+37067;enge im simmental
+37068;oron
+37069;kreuzstrasse
+37070;matten
+37071;la faverge
+37072;le reymond
+37073;martigny-bourg
+37074;pont de fayot
+37075;lugano flp
+37076;surovas
+37077;flamatt dorf
+37078;oberzollikofen
+37079;jor
+37080;la chaux-de-fonds-est
+37081;gluringen
+37082;bussnang
+37083;gontenbad
+37084;montétan
+37085;pré-petitjean
+37086;auvernier littorail
+37087;brunnadern-neckertal
+37088;clies
+37089;montreux-les planches
+37090;chez-le-maître-ecoles
+37091;stalden i.e.
+37092;wilen
+37093;münster vs
+37094;col-de-soud
+37095;rothenbrunnen
+37096;trin
+37097;le lussex
+37098;capolago lago
+37099;bernina suot
+37100;seewis-valzeina
+37101;weissenbach
+37102;burgholz
+37103;lattigen bei spiez
+37104;moos
+37105;schindellegi-feusisberg
+37106;trois-villes
+37107;glion-alpes
+37108;sorengo laghetto
+37109;gilamont
+37110;jakobstal
+37111;schynige platte
+37112;davos wiesen
+37113;lengwil
+37114;vers-l’eglise
+37115;sandbüchel
+37116;gettnau
+37117;fleurier
+37118;lax
+37119;les granges-gérignoz
+37120;brenzikofen
+37121;kräbel
+37122;laupen
+37123;bremgarten obertor
+37124;bercher
+37125;rennaz (leysin)
+37126;acla da fontauna
+37127;breitlauenen
+37128;monthey-en place
+37129;eifeld
+37130;guarda
+37131;cavaglia
+37132;sihlwald
+37133;steinibach
+37134;geschinen
+37135;hospental
+37136;ipsach
+37137;unterkulm nord
+37138;riedholz
+37139;schützengarten
+37140;kehrsatz nord
+37141;monthey-ville
+37142;aathal
+37143;talhaus
+37144;zufikon
+37145;ramsei
+37146;bonfol
+37147;les charbonnières
+37148;bioggio molinazzo
+37149;les cases
+37150;carolina
+37151;les pléiades
+37152;seebleiche
+37153;innertkirchen unterwasser
+37154;la clairière
+37155;herbriggen
+37156;leimbach ag
+37157;gampelen
+37158;châtelard vd
+37159;vernayaz mc
+37160;rothenthurm
+37161;muhen
+37162;zweilütschinen
+37163;ondallaz-l’alliaz
+37164;jaman
+37165;mittelhäusern
+37166;môtiers
+37167;oberwil im simmental
+37168;valendas-sagogn
+37169;lädeli
+37170;igis
+37171;uetendorf
+37172;punt muragl staz
+37173;haldenstein
+37174;schachen (gais)
+37175;gruben
+37176;pensier
+37177;neuthal
+37178;flendruz
+37179;enney
+37180;zürich rehalp
+37181;colombier ne allées littorail
+37182;st-triphon-gare
+37183;st-gallen riethüsli
+37184;madiswil
+37185;colombier ne littorail
+37186;jungfraujoch
+37187;gelfingen
+37188;ftan baraigla
+37189;klus
+37190;vendlincourt
+37191;bévieux
+37192;hüswil
+37193;neue forch
+37194;malans
+37195;grosshöchstetten
+37196;la chiésaz
+37197;niederbipp industrie
+37198;la tour-de-trême
+37199;bernina lagalb
+37200;la douay
+37201;rigi kaltbad-first
+37202;thörishaus station
+37203;les marécottes
+37204;le pâquier-montbarry
+37205;sugiez
+37206;oberdorf bl
+37207;däniken
+37208;la sarraz
+37209;benken
+37210;sennhof-kyburg
+37211;eschlikon
+37212;möhlin
+37213;buckten
+37214;kloten balsberg
+37215;neuchâtel-serrières
+37216;roche vd
+37217;oberglatt
+37218;bossière
+37219;küngoldingen
+37220;urdorf
+37221;twann
+37222;le crêt-du-locle
+37223;horgen oberdorf
+37224;stettbach
+37225;seuzach
+37226;ecublens-rue
+37227;eschenz
+37228;diesbach-betschwanden
+37229;ennenda
+37230;marthalen
+37231;boniswil
+37232;léchelles
+37233;arnex
+37234;cortébert
+37235;magadino-vira
+37236;wynigen
+37237;nidfurn-haslen
+37238;yvonand
+37239;wangen bei olten
+37240;münchenbuchsee
+37241;feldbach
+37242;gümligen
+37243;baldegg
+37244;mühlehorn
+37245;tägerwilen-gottlieben
+37246;rhäzüns
+37247;nebikon
+37248;hergiswil matt
+37249;burier
+37250;plan morier
+37251;därstetten
+37252;les aviolats
+37253;sorengo
+37254;uttigen
+37255;grubisbalm
+37256;aarwangen
+37257;st-katharinen
+37258;li curt
+37259;kehrsatz
+37260;aefligen
+37261;brienz west
+37262;le locle-col-des-roches
+37263;muriaux
+37264;cossonay-penthalaz
+37265;gland
+37266;alpiglen
+37267;maroggia-melano
+37268;bottighofen
+37269;bettlach
+37270;bonstetten-wettswil
+37271;baulmes
+37272;binzenhof
+37273;birrwil
+37274;bex-place-du-marché
+37275;boltigen
+37276;boswil-bünzen
+37277;grandvillard
+37278;bugnei
+37279;düdingen
+37280;hasle-rüegsau
+37281;dietikon schöneggstrasse
+37282;chigny
+37283;griesbach
+37284;dürrenroth
+37285;la tour-de-trême ronclina
+37286;ettenhausen-emmetschloo
+37287;lohn-lüterkofen
+37288;massongex
+37289;les reussilles
+37290;felben-wellhausen
+37291;huttwil sportzentrum
+37292;muntelier-löwenberg
+37293;münchwilen pflegeheim
+37294;sutz
+37295;täuffelen
+37296;bussy-chardonney
+37297;grütschalp
+37298;landquart ried
+37299;erlenbach im simmental
+37300;castrisch
+37301;walkringen
+37302;lotzwil
+37303;winterthur wallrüti
+37304;veytaux-chillon
+37305;aigle-place-du-marché
+37306;neuhaus bei hinteregg
+37307;langwies gr
+37308;chur stadt
+37309;reinach ag
+37310;strahlholz
+37311;bois-de-chexbres
+37312;lyss grien
+37313;neuchâtel champ-bougin
+37314;moosseedorf
+37315;worb dorf
+37316;fraubrunnen
+37317;bollement
+37318;les montuires
+37319;combe-tabeillon
+37320;blonay
+37321;bibenlos-sonnenhof
+37322;spital zollikerberg
+37323;brandegg
+37324;zürich wollishofen
+37325;corcelles-peseux
+37326;freibergen
+37327;horn
+37328;bossonnens
+37329;prilly-chasseur
+37330;pont-céard
+37331;flumenthal
+37332;esslingen
+37333;niederscherli
+37334;les coeudres
+37335;pont-de-drapel
+37336;grafenried
+37337;arth-goldau rb
+37338;hirschthal
+37339;ewil maxon
+37340;belmont-sur-montreux
+37341;grünenmatt
+37342;miralago
+37343;meiringen alpbach
+37344;roggwil-berg
+37345;quartino
+37346;st-gallen spisertor
+37347;hard-mumenthal
+37348;peist
+37349;croix-du-nant
+37350;aemsigen
+37351;stettlen
+37352;les arnoux
+37353;lampenberg-ramlinsburg
+37354;bern wankdorf
+37355;oberentfelden uerkenbrücke
+37356;susch
+37357;rotenboden
+37358;burgistein
+37359;oberbipp
+37360;steigbach
+37361;spinas
+37362;erdmannlistein
+37363;siegershausen
+37364;monthey
+37365;cavigliano
+37366;wila
+37367;siselen-finsterhennen
+37368;la punt-chamues-ch
+37369;auvernier
+37370;stöckli
+37371;safenwil
+37372;bex pont-neuf
+37373;kaiserstuhl ag
+37374;hunzenschwil
+37375;lausanne-flon
+37376;etagnières
+37377;littau
+37378;corcelles-sud
+37379;buchs-dällikon
+37380;solothurn west
+37381;tüscherz
+37382;rekingen ag
+37383;uetikon
+37384;zollikon
+37385;reconvilier
+37386;schübelbach-buttikon
+37387;herrliberg-feldmeilen
+37388;steg
+37389;charrat-fully
+37390;koblenz
+37391;elgg
+37392;bern wyleregg
+37393;basel zoo
+37394;sierre muraz
+37395;venthône
+37396;darnona
+37397;st-maurice-de-laques
+37398;bluche-randogne
+37399;marigny
+37400;bern
+37401;arcades
+37403;abenfigo
+37404;ablaneda
+37405;agramunt
+37406;agrupacion sto tome
+37407;aguaviva
+37408;alacón
+37409;alarcia
+37410;albox
+37411;albuñol
+37412;alburquerque
+37413;alcalá de los gazules
+37414;alcaudete
+37415;alcorisa
+37416;alcuéscar
+37417;aldea de san esteban
+37418;alfambra
+37419;algarinejo
+37420;algodonales
+37421;alloza
+37422;almaciles
+37423;almándoz
+37424;almanzora
+37425;almenar
+37426;almonacid de la cuba
+37427;almurfe
+37428;alomartes
+37429;andorra
+37430;angues
+37431;aribe
+37432;ariño
+37433;armuña
+37434;arraitz-orkin
+37435;arrieta
+37436;arroyo del ojanco
+37437;arroyomolinos de león
+37438;arsèguel
+37439;artesa de segre
+37440;as pontes de garcía rodríguez
+37441;auguasmestas
+37442;ayllón
+37443;azares del páramo
+37444;azuara
+37445;baells
+37446;balerma
+37447;balsareny
+37448;baños de valdearados
+37449;barahona
+37450;barcia
+37451;barcial de la loma
+37452;barinas
+37453;baro
+37454;barranda
+37455;barreras
+37456;barruera
+37457;bayárcal
+37458;bebares
+37459;beceite
+37460;belchite
+37461;beleño
+37462;bellaguarda
+37463;belmonte de san josé
+37464;belorado
+37465;belver de cinca
+37466;benagalbón
+37467;benajarafe
+37468;benalup-casas viejas
+37469;benavent
+37470;benifallet
+37471;bérchules
+37472;berrocalejo
+37473;béznar
+37474;bigüézal
+37475;biscarri
+37476;boca de huérgano
+37477;boceguillas
+37478;boí
+37479;bornos
+37480;borredà
+37481;bot
+37482;brácana
+37483;bujaraloz
+37484;burguillos del cerro
+37485;burón
+37486;cabanillas de la sierra
+37487;cabeza la vaca
+37488;cabezas rubias
+37489;cabrillanes
+37490;cabruñana
+37491;cadavedo
+37492;cadiñanos
+37493;cala
+37494;calaceite
+37495;calanda
+37496;calera de león
+37497;caleruega
+37498;calonge
+37499;calzadilla
+37500;camarinas
+37501;campillo de arenas
+37502;campofrío
+37503;camporredondo
+37504;candasnos
+37505;canjáyar
+37506;cantoria
+37507;capileira
+37508;carataunas
+37509;carbajal de valderaduey
+37510;carballo
+37511;carboneras
+37512;carboniella
+37513;carcabuey
+37514;cárcamo
+37515;cebrones del río
+37516;cervo
+37517;cojáyar
+37518;degaña
+37519;deleitosa
+37520;el castell de guadalest
+37521;el gordo
+37522;estartit
+37523;fiscal
+37524;fontanillas de castro
+37525;fuentiduena de tajo
+37526;garde
+37527;guaro
+37528;guímara
+37529;ibiza
+37530;javier
+37531;la alqueria
+37532;lago
+37533;legutio
+37534;los alburejos
+37535;los santos
+37536;mezquitilla
+37537;montecillo
+37538;narros
+37539;o campo do hospital
+37540;palomas
+37541;plasenzuela
+37543;puebla de alborton
+37544;quintanilla
+37545;romo
+37546;saludes
+37547;santa magdalena
+37548;sant antoni de portmany
+37549;santa quiteria
+37550;santed
+37551;santo tomé
+37552;santo tomé del puerto
+37553;sena
+37554;torrente
+37555;vélez-málaga
+37556;yegen
+37557;zubiri
+37558;saint jean de sixt
+37559;thônes
+37560;arangjelovac
+37561;bajina bauta
+37562;ferizovik
+37563;sant julià de lòria
+37564;alajar
+37565;albalate del arzobispo
+37566;albares de la ribera
+37567;alcalá de guadaira
+37568;alcalá del valle
+37569;alcanar
+37570;alcudia
+37572;alfara de carles
+37573;alforque
+37574;algatocín
+37575;almanza
+37576;alosno
+37577;altube
+37578;amurrio
+37579;anero
+37580;angles
+37581;angulo
+37584;arbeca
+37585;arbulu
+37586;ardales
+37587;ardoncino
+37588;armilla
+37589;køge nord st.
+37590;nicosia
+37591;nicosia ercan airport
+37592;kyrenia
+37593;famagusta
+37594;bafra
+37595;esentepe
+37596;karşıyaka
+37597;knam
+37598;thessaloniki airport
+37599;kefalos
+37600;kardamena
+37601;mastichari
+37602;marmari
+37603;tigkaki
+37604;kos
+37605;kos airport
+37606;jezerce
+37607;nicosia larnaca airport
+37608;arcozelo
+37609;gabicce mare
+37610;malhadas
+37611;schilpario
+37612;lido adriano
+37613;malmö airport
+37614;stockholm bromma airport
+37615;stockholm skavsta airport
+37616;stockholm vasteras airport
+37617;svedala
+37618;staffanstorp
+37619;landvetter
+37620;solna
+37621;sundbyberg
+37622;bromma
+37623;kista
+37624;alixan
+37625;tranås
+37626;sjötorp
+37627;habo
+37628;smedjebacken
+37629;vetlanda
+37630;gullspång
+37631;fagersta
+37632;braås
+37633;mullsjö
+37634;söderbärke
+37635;motala
+37636;tanumshede
+37637;eksjö
+37638;skövde
+37639;eskilstuna
+37640;falköping
+37641;ludvika
+37642;mariestad
+37643;otterbäcken
+37644;arboga
+37645;lindshammar
+37646;boxholm
+37647;sommen
+37648;ekenässjön
+37649;vadstena
+37650;marbäck
+37651;korsberga
+37652;sundhultsbrunn
+37653;norrhult
+37654;bankeryd
+37655;buna
+37656;yuzhne
+37657;chornomorsk
+37658;koblevo
+37659;satoka
+37660;olgiate comasco
+37661;casatenovo
+37662;mendola
+37663;naklo nad notecia
+37664;sofades
+37665;derveni
+37666;pavlohrad
+37667;kamianske
+37668;volodymyr volynskyi
+37669;karditsa
+37670;trikala
+37671;boskovice
+37672;siltse
+37673;vysoké tatry
+37674;vyšne nemecké
+37675;ždiar
+37676;bukowina tatrzańska
+37677;bialka tatrzanska
+37678;gargždai
+37679;kuršėnai
+37680;elektrėnai
+37681;visaginas
+37682;naujoji akmenė
+37683;anykščiai
+37684;biržai
+37685;ignalina
+37686;jonava
+37687;joniškis
+37688;jurbarkas
+37689;kelmė
+37690;kupiškis
+37691;lazdijai
+37692;mažeikiai
+37693;molėtai
+37694;pakruojis
+37695;pasvalys
+37696;prienai
+37697;radviliškis
+37698;raseiniai
+37699;rokiškis
+37700;skuodas
+37701;sakiai
+37702;silale
+37703;silute
+37704;tauragė
+37705;trakai
+37706;ukmerge
+37707;utena
+37708;varėna
+37709;vilkaviškis
+37710;zarasai
+37711;nida
+37712;chrysoupoli
+37713;paralia ofriniou
+37714;la clusaz
+37715;cruseilles
+37716;le grand bornand
+37717;douvaine
+37718;nea kerdilia
+37719;asprovalta
+37720;rentina
+37721;methoni
+37722;pyrgetos
+37723;pelasgia
+37724;molos agios konstantinos
+37725;lokroi
+37726;thebes
+37727;tanagra
+37728;oropos
+37729;peristeri
+37730;delta gr
+37731;aiginio
+37732;leptokarya
+37733;dio olympos
+37734;sidirodromikos stathmos rapsanis
+37735;tempi
+37736;stefanovikeio
+37737;mikrothives
+37738;almiros
+37739;adler
+37740;sourpi
+37741;babruysk
+37742;karavomylos
+37743;stilida
+37744;chernihiv
+37745;drohobych
+37746;gomel
+37747;hrebenne
+37748;izmayil
+37749;krakovets
+37750;orchomenos
+37751;sorokyne
+37752;luhansk
+37753;dionysos
+37754;molodohvardiysk
+37755;novaya guta
+37756;rawa ruska
+37757;sochi
+37758;truskavec
+37759;tuapse
+37760;volgograd
+37761;volochys’k
+37762;meta
+37763;piano di sorrento
+37764;sant’agnello
+37765;volzhskiy
+37766;volyns’ka oblast
+37767;skytok
+37768;letychiv
+37769;shehyni
+37770;sverdlovs’k
+37771;polotsk
+37772;antratsyt
+37773;kamianka
+37774;ablanitsa
+37775;aytos
+37776;albena
+37777;andalo
+37778;amfissa
+37779;antonovo
+37780;baltchik
+37781;balgarski izvor
+37782;botevgrad
+37783;sciez
+37784;byala
+37785;gabrovo
+37786;dragomirovo
+37787;dulovo
+37788;dupnitsa
+37789;zlatna panega
+37790;isperih
+37791;ihtiman
+37792;kavarna
+37793;kazanlak
+37794;kalamata
+37795;kalofer
+37796;karnobat
+37797;katuntsi
+37798;kyllini
+37799;konyavo
+37800;corinth
+37801;kresna
+37802;kubrat
+37803;kulata
+37804;kyustendil
+37805;lovech
+37806;lukovit
+37807;gimont
+37808;nova zagora
+37809;obnova
+37810;omurtag
+37811;pavel banya
+37812;pernik
+37813;petrevene
+37814;petrich
+37815;pyrgos
+37816;pravets
+37817;radomir
+37818;razlog
+37819;rozino
+37820;sveti vlas
+37821;svishtov
+37822;sevlievo
+37823;serres
+37824;simitli
+37825;sopot
+37826;strumyani
+37827;troyan
+37828;tryavna
+37829;targovishte
+37830;tsarvendol
+37831;shabla
+37832;yablanitsa
+37833;florange
+37834;kungsor
+37835;strangnas
+37836;amneville
+37837;dobrinishte
+37838;macanet de la selva
+37839;lido di volano
+37840;kinna
+37841;mogilev
+37842;orsha
+37843;vitebsk
+37844;haapsalu
+37845;johvi
+37846;kohtla jarve
+37847;kuressaare
+37848;narva
+37849;rivedoux plage
+37850;la flotte
+37851;rakvere
+37852;sillamae
+37853;tartu
+37854;valga
+37855;viljandi
+37856;voru
+37857;helsinki
+37858;kotka
+37859;daugavpils
+37860;jelgava
+37861;valmiera
+37862;gvardeysk
+37863;kingisepp
+37864;pskov
+37865;howald


### PR DESCRIPTION
In response to the issue here: https://github.com/tducret/trainline-python/issues/6

This PR filters out the stations that don't have the `is_suggestable` field set to True, so that we can only make searches on Trainline API that would return data.